### PR TITLE
Add AskAsset type to dex

### DIFF
--- a/contracts/modules/apis/dex/src/commands.rs
+++ b/contracts/modules/apis/dex/src/commands.rs
@@ -7,6 +7,7 @@ use abstract_os::{
     dex::{DexAction, OfferAsset, SwapRouter},
     objects::{AssetEntry, UncheckedContractEntry},
 };
+use abstract_os::dex::AskAsset;
 
 pub const PROVIDE_LIQUIDITY: u64 = 7542;
 pub const PROVIDE_LIQUIDITY_SYM: u64 = 7543;
@@ -133,7 +134,7 @@ pub trait LocalDex: MemoryOperation + OsExecute {
         &self,
         _deps: Deps,
         _offer_assets: Vec<OfferAsset>,
-        _ask_assets: Vec<OfferAsset>,
+        _ask_assets: Vec<AskAsset>,
         _exchange: &dyn DEX,
         _max_spread: Option<Decimal>,
         _router: Option<SwapRouter>,

--- a/packages/abstract-os/src/dex.rs
+++ b/packages/abstract-os/src/dex.rs
@@ -9,6 +9,7 @@ use crate::objects::{AssetEntry, ContractEntry};
 
 pub type DexName = String;
 pub type OfferAsset = (AssetEntry, Uint128);
+pub type AskAsset = OfferAsset;
 
 pub const IBC_DEX_ID: u32 = 11335;
 
@@ -44,7 +45,7 @@ pub enum DexAction {
     /// Allow alternative swap routers and methods
     CustomSwap {
         offer_assets: Vec<OfferAsset>,
-        ask_assets: Vec<OfferAsset>,
+        ask_assets: Vec<AskAsset>,
         max_spread: Option<Decimal>,
         /// Optionally supply a router to use
         router: Option<SwapRouter>,

--- a/packages/abstract-sdk/src/exchange.rs
+++ b/packages/abstract-sdk/src/exchange.rs
@@ -6,7 +6,7 @@ use abstract_os::{
 use cosmwasm_std::{CosmosMsg, Deps, StdResult};
 
 use crate::Dependency;
-use abstract_os::dex::DexRequestMsg;
+use abstract_os::dex::{AskAsset, DexRequestMsg};
 
 /// Perform actions on an exchange API.
 /// WIP
@@ -38,7 +38,7 @@ pub trait Exchange: Dependency {
         deps: Deps,
         dex: String,
         offer_assets: Vec<OfferAsset>,
-        ask_assets: Vec<OfferAsset>,
+        ask_assets: Vec<AskAsset>,
         router: Option<SwapRouter>,
     ) -> StdResult<CosmosMsg> {
         self.call_api_dependency(


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- add a :black_small_square: in the boxes that apply -->
:white_small_square: Bugfix
:white_small_square: New feature
▪️ : Enhancement
:white_small_square: Refactoring
:white_small_square: Maintenance

## :scroll: Description and Motivation
<!--- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This change simply adds an `AskAsset` type to the dex API. It is the same as `OfferAsset`.

## :hammer_and_wrench: How to test (if applicable)
<!--- Describe the steps the reviewer needs to take to verify the changes -->


## :pencil: Checklist
<!--- add a :black_small_square: in the boxes that apply -->

:white_small_square: Reviewed submitted code
:white_small_square: Added tests to verify changes
:white_small_square: Updated docs
:white_small_square: Verified on testnet
