### PR TITLE
Update actions to cancel concurrent runs and actually check all rust files

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -2,8 +2,8 @@ name: Clippy & Tests
 on:
   pull_request:
     branches:
-     - main
-     - dev
+      - main
+      - dev
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -13,6 +13,11 @@ on:
         type: boolean
         default: false
         required: false
+
+# Cancel previous runs on the same PR.
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   check_changes:
@@ -26,12 +31,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Check if any rust files have changed
         id: changes
         uses: tj-actions/changed-files@v35
         with:
           files: |
-            *.rs
+            **/*.rs
             Cargo.toml
             Cargo.lock
       - name: Check if any rust files have changed

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
         uses: tj-actions/changed-files@v35
         with:
           files: |
-            *.rs
+            **/*.rs
             Cargo.toml
             Cargo.lock
       - name: Check if any rust files have changed


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- add a :black_small_square: in the boxes that apply -->
:white_small_square: Bugfix
:white_small_square: New feature
:white_small_square: Enhancement
:white_small_square: Refactoring
:white_small_square: Maintenance

## :scroll: Description and Motivation
<!--- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This change updates the files changed check so that it actually checks all rust files (through the glob) and also adds a concurrency cancellation setting. This setting makes it so that runs with the same PR. SEe https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-concurrency-to-cancel-any-in-progress-job-or-run


## :hammer_and_wrench: How to test (if applicable)
<!--- Describe the steps the reviewer needs to take to verify the changes -->


## :pencil: Checklist
<!--- add a :black_small_square: in the boxes that apply -->

:white_small_square: Reviewed submitted code
:white_small_square: Added tests to verify changes
:white_small_square: Updated docs
:white_small_square: Verified on testnet
