### PR TITLE
Add support for transferring both `AnsAsset` and `cw_asset::Asset` types using the `Bank` API

### DIFF
--- a/packages/abstract-sdk/README.md
+++ b/packages/abstract-sdk/README.md
@@ -62,7 +62,7 @@ impl<'a, T: SplitterInterface> Splitter<'a, T> {
             .iter()
             .map(|receiver| {
                 // Construct the transfer message
-                bank.transfer(vec![receives_each.clone()], receiver)
+                bank.transfer(vec![&receives_each], receiver)
             })
             .collect();
 

--- a/packages/abstract-sdk/src/ans_resolve.rs
+++ b/packages/abstract-sdk/src/ans_resolve.rs
@@ -30,6 +30,17 @@ impl Resolve for AssetEntry {
     }
 }
 
+impl Resolve for &AssetEntry {
+    type Output = AssetInfo;
+    fn resolve(
+        &self,
+        querier: &QuerierWrapper,
+        ans_host: &AnsHost,
+    ) -> AbstractSdkResult<Self::Output> {
+        ans_host.query_asset(querier, self).map_err(Into::into)
+    }
+}
+
 /// TODO: this should be moved into a more appropriate package (with the LP token)
 impl Resolve for LpToken {
     type Output = AssetInfo;
@@ -94,6 +105,21 @@ impl Resolve for UniquePoolId {
 }
 
 impl Resolve for AnsAsset {
+    type Output = Asset;
+
+    fn resolve(
+        &self,
+        querier: &QuerierWrapper,
+        ans_host: &AnsHost,
+    ) -> AbstractSdkResult<Self::Output> {
+        Ok(Asset::new(
+            ans_host.query_asset(querier, &self.name)?,
+            self.amount,
+        ))
+    }
+}
+
+impl Resolve for &AnsAsset {
     type Output = Asset;
 
     fn resolve(

--- a/packages/abstract-sdk/src/apis/splitter.rs
+++ b/packages/abstract-sdk/src/apis/splitter.rs
@@ -37,7 +37,7 @@ impl<'a, T: SplitterInterface> Splitter<'a, T> {
             .iter()
             .map(|receiver| {
                 // Construct the transfer message
-                bank.transfer(vec![receives_each.clone()], receiver)
+                bank.transfer(vec![&receives_each], receiver)
             })
             .collect();
 


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- add a :black_small_square: in the boxes that apply -->
:white_small_square: Bugfix
:white_small_square: New feature
:black_small_square: Enhancement
:white_small_square: Refactoring
:white_small_square: Maintenance

## :scroll: Description and Motivation
<!--- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Adds the ability to transfer both types of assets to reduce un-needed ANS lookups.

## :hammer_and_wrench: How to test (if applicable)
<!--- Describe the steps the reviewer needs to take to verify the changes -->


## :pencil: Checklist
<!--- add a :black_small_square: in the boxes that apply -->

:white_small_square: Reviewed submitted code
:white_small_square: Added tests to verify changes
:white_small_square: Updated docs
:white_small_square: Verified on testnet
