### PR TITLE
Add reply handler to API endpoint

### DIFF
--- a/packages/abstract-api/src/endpoints.rs
+++ b/packages/abstract-api/src/endpoints.rs
@@ -1,22 +1,23 @@
 mod execute;
 mod ibc_callback;
-pub mod instantiate;
+mod instantiate;
 mod query;
 mod receive;
+mod reply;
 
 #[macro_export]
 macro_rules! export_endpoints {
-    ($app_const:expr, $app_type:ty) => {
+    ($api_const:expr, $api_type:ty) => {
         /// Instantiate entrypoint
         #[::cosmwasm_std::entry_point]
         pub fn instantiate(
             deps: ::cosmwasm_std::DepsMut,
             env: ::cosmwasm_std::Env,
             info: ::cosmwasm_std::MessageInfo,
-            msg: <$app_type as ::abstract_sdk::base::InstantiateEndpoint>::InstantiateMsg,
-        ) -> Result<::cosmwasm_std::Response, <$app_type as ::abstract_sdk::base::Handler>::Error> {
+            msg: <$api_type as ::abstract_sdk::base::InstantiateEndpoint>::InstantiateMsg,
+        ) -> Result<::cosmwasm_std::Response, <$api_type as ::abstract_sdk::base::Handler>::Error> {
             use ::abstract_sdk::base::InstantiateEndpoint;
-            $app_const.instantiate(deps, env, info, msg)
+            $api_const.instantiate(deps, env, info, msg)
         }
 
         /// Execute entrypoint
@@ -25,10 +26,10 @@ macro_rules! export_endpoints {
             deps: ::cosmwasm_std::DepsMut,
             env: ::cosmwasm_std::Env,
             info: ::cosmwasm_std::MessageInfo,
-            msg: <$app_type as ::abstract_sdk::base::ExecuteEndpoint>::ExecuteMsg,
-        ) -> Result<::cosmwasm_std::Response, <$app_type as ::abstract_sdk::base::Handler>::Error> {
+            msg: <$api_type as ::abstract_sdk::base::ExecuteEndpoint>::ExecuteMsg,
+        ) -> Result<::cosmwasm_std::Response, <$api_type as ::abstract_sdk::base::Handler>::Error> {
             use ::abstract_sdk::base::ExecuteEndpoint;
-            $app_const.execute(deps, env, info, msg)
+            $api_const.execute(deps, env, info, msg)
         }
 
         /// Query entrypoint
@@ -36,10 +37,21 @@ macro_rules! export_endpoints {
         pub fn query(
             deps: ::cosmwasm_std::Deps,
             env: ::cosmwasm_std::Env,
-            msg: <$app_type as ::abstract_sdk::base::QueryEndpoint>::QueryMsg,
-        ) -> Result<::cosmwasm_std::Binary, <$app_type as ::abstract_sdk::base::Handler>::Error> {
+            msg: <$api_type as ::abstract_sdk::base::QueryEndpoint>::QueryMsg,
+        ) -> Result<::cosmwasm_std::Binary, <$api_type as ::abstract_sdk::base::Handler>::Error> {
             use ::abstract_sdk::base::QueryEndpoint;
-            $app_const.query(deps, env, msg)
+            $api_const.query(deps, env, msg)
+        }
+
+        // Reply entrypoint
+        #[::cosmwasm_std::entry_point]
+        pub fn reply(
+            deps: ::cosmwasm_std::DepsMut,
+            env: ::cosmwasm_std::Env,
+            msg: ::cosmwasm_std::Reply,
+        ) -> Result<::cosmwasm_std::Response, <$api_type as ::abstract_sdk::base::Handler>::Error> {
+            use ::abstract_sdk::base::ReplyEndpoint;
+            $api_const.reply(deps, env, msg)
         }
     };
 }

--- a/packages/abstract-api/src/endpoints/reply.rs
+++ b/packages/abstract-api/src/endpoints/reply.rs
@@ -1,0 +1,14 @@
+use abstract_sdk::base::ReplyEndpoint;
+
+use crate::{ApiContract, ApiError};
+
+impl<
+        Error: From<cosmwasm_std::StdError> + From<ApiError> + From<abstract_sdk::AbstractSdkError>,
+        CustomInitMsg,
+        CustomExecMsg,
+        CustomQueryMsg,
+        ReceiveMsg,
+    > ReplyEndpoint
+    for ApiContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg>
+{
+}


### PR DESCRIPTION
Add the `ReplyEndpoint` trait and it's endpoint to the api macro. 

This allows API's to set up reply handlers.