### PR TITLE
Underscore actions in Responses

### DIFF
--- a/contracts/native/ibc-client/src/ibc.rs
+++ b/contracts/native/ibc-client/src/ibc.rs
@@ -259,7 +259,7 @@ fn acknowledge_register(
         }
     })?;
 
-    Ok(IbcBasicResponse::new().add_attribute("action", "acknowledge_who_am_i"))
+    Ok(IbcBasicResponse::new().add_attribute("action", "acknowledge_register"))
 }
 
 // receive PacketMsg::Balances response

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -106,5 +106,5 @@ fn authorized_set_admin<C: std::clone::Clone + std::fmt::Debug + std::cmp::Parti
 
     let new_admin_addr = deps.api.addr_validate(&new_admin)?;
     admin_to_update.set(deps, Some(new_admin_addr))?;
-    Ok(Response::new().add_attribute("Set admin item to:", new_admin))
+    Ok(Response::new().add_attribute("set_admin", new_admin))
 }

--- a/contracts/token/src/contract.rs
+++ b/contracts/token/src/contract.rs
@@ -226,5 +226,5 @@ fn update_whitelist(
         config.transfers_restricted = restict;
     };
     CONFIG.save(deps.storage, &config)?;
-    Ok(Response::new().add_attribute("action", "updated contract addresses"))
+    Ok(Response::new().add_attribute("action", "updated_contract_addresses"))
 }

--- a/packages/abstract-api/src/endpoints/execute.rs
+++ b/packages/abstract-api/src/endpoints/execute.rs
@@ -159,7 +159,7 @@ impl<
             );
         }
         self.executor(deps)
-            .execute_with_response(msgs, "remove api from dependencies")
+            .execute_with_response(msgs, "remove_api_from_dependencies")
             .map_err(Into::into)
     }
 


### PR DESCRIPTION
This change makes some "mishandled" actions more consistent for parsing in indexers.