### PR TITLE
Audit #10: Limit the number of authorized addresses

### DIFF
--- a/contracts/account/manager/src/commands.rs
+++ b/contracts/account/manager/src/commands.rs
@@ -373,10 +373,13 @@ pub fn replace_api(
     let mut msgs = vec![];
     // Makes sure we already have the api installed
     let proxy_addr = ACCOUNT_MODULES.load(deps.storage, PROXY)?;
+    // TODO: page limit loop
     let TradersResponse { traders } = deps.querier.query(&wasm_smart_query(
         old_api_addr.to_string(),
         &<ApiQuery<Empty>>::Base(BaseQueryMsg::Traders {
             proxy_address: proxy_addr.to_string(),
+            limit: None,
+            start_after: None,
         }),
     )?)?;
     let traders_to_migrate: Vec<String> =

--- a/contracts/account/manager/src/commands.rs
+++ b/contracts/account/manager/src/commands.rs
@@ -27,7 +27,8 @@ use abstract_sdk::{
 };
 
 use abstract_core::api::{
-    BaseExecuteMsg, BaseQueryMsg, ExecuteMsg as ApiExecMsg, QueryMsg as ApiQuery, TradersResponse,
+    AuthorizedAddressesResponse, BaseExecuteMsg, BaseQueryMsg, ExecuteMsg as ApiExecMsg,
+    QueryMsg as ApiQuery,
 };
 use abstract_sdk::cw_helpers::cosmwasm_std::AbstractAttributes;
 use cosmwasm_std::{
@@ -300,7 +301,7 @@ pub fn set_migrate_msgs_and_context(
     let id = module_info.id();
 
     match module.reference {
-        // upgrading an api is done by moving the traders to the new contract address and updating the permissions on the proxy.
+        // upgrading an api is done by moving the authorized addresses to the new contract address and updating the permissions on the proxy.
         ModuleReference::Api(addr) => {
             versioning::assert_migrate_requirements(
                 deps.as_ref(),
@@ -364,7 +365,7 @@ fn get_migrate_msg(module_addr: Addr, new_code_id: u64, migrate_msg: Binary) -> 
 }
 
 /// Replaces the current api with a different version
-/// Also moves all the trader permissions to the new contract and removes them from the old
+/// Also moves all the authorized address permissions to the new contract and removes them from the old
 pub fn replace_api(
     deps: DepsMut,
     new_api_addr: Addr,
@@ -374,31 +375,35 @@ pub fn replace_api(
     // Makes sure we already have the api installed
     let proxy_addr = ACCOUNT_MODULES.load(deps.storage, PROXY)?;
     // TODO: page limit loop
-    let TradersResponse { traders } = deps.querier.query(&wasm_smart_query(
+    let AuthorizedAddressesResponse {
+        addresses: authorized_addresses,
+    } = deps.querier.query(&wasm_smart_query(
         old_api_addr.to_string(),
-        &<ApiQuery<Empty>>::Base(BaseQueryMsg::Traders {
+        &<ApiQuery<Empty>>::Base(BaseQueryMsg::AuthorizedAddresses {
             proxy_address: proxy_addr.to_string(),
             limit: None,
             start_after: None,
         }),
     )?)?;
-    let traders_to_migrate: Vec<String> =
-        traders.into_iter().map(|addr| addr.into_string()).collect();
-    // Remove traders from old
+    let authorized_to_migrate: Vec<String> = authorized_addresses
+        .into_iter()
+        .map(|addr| addr.into_string())
+        .collect();
+    // Remove authorized addresses from old
     msgs.push(configure_api(
         &old_api_addr,
-        BaseExecuteMsg::UpdateTraders {
+        BaseExecuteMsg::UpdateAuthorizedAddresses {
             to_add: vec![],
-            to_remove: traders_to_migrate.clone(),
+            to_remove: authorized_to_migrate.clone(),
         },
     )?);
-    // Remove api as trader on dependencies
+    // Remove api as authorized address on dependencies
     msgs.push(configure_api(&old_api_addr, BaseExecuteMsg::Remove {})?);
-    // Add traders to new
+    // Add authorized addresses to new
     msgs.push(configure_api(
         &new_api_addr,
-        BaseExecuteMsg::UpdateTraders {
-            to_add: traders_to_migrate,
+        BaseExecuteMsg::UpdateAuthorizedAddresses {
+            to_add: authorized_to_migrate,
             to_remove: vec![],
         },
     )?);

--- a/contracts/account/manager/src/commands.rs
+++ b/contracts/account/manager/src/commands.rs
@@ -374,15 +374,12 @@ pub fn replace_api(
     let mut msgs = vec![];
     // Makes sure we already have the api installed
     let proxy_addr = ACCOUNT_MODULES.load(deps.storage, PROXY)?;
-    // TODO: page limit loop
     let AuthorizedAddressesResponse {
         addresses: authorized_addresses,
     } = deps.querier.query(&wasm_smart_query(
         old_api_addr.to_string(),
         &<ApiQuery<Empty>>::Base(BaseQueryMsg::AuthorizedAddresses {
             proxy_address: proxy_addr.to_string(),
-            limit: None,
-            start_after: None,
         }),
     )?)?;
     let authorized_to_migrate: Vec<String> = authorized_addresses

--- a/contracts/account/manager/tests/apis.rs
+++ b/contracts/account/manager/tests/apis.rs
@@ -55,7 +55,7 @@ fn installing_one_api_should_succeed() -> AResult {
     });
 
     // no authorized addresses registered
-    let authorized = staking_api.authorized_addresses(account.proxy.addr_str()?, None, None)?;
+    let authorized = staking_api.authorized_addresses(account.proxy.addr_str()?)?;
     assert_that!(authorized).is_equal_to(api::AuthorizedAddressesResponse { addresses: vec![] });
 
     Ok(())

--- a/contracts/account/manager/tests/apis.rs
+++ b/contracts/account/manager/tests/apis.rs
@@ -54,9 +54,9 @@ fn installing_one_api_should_succeed() -> AResult {
         version_control_address: deployment.version_control.address()?,
     });
 
-    // no traders registered
-    let traders = staking_api.traders(account.proxy.addr_str()?, None, None)?;
-    assert_that!(traders).is_equal_to(api::TradersResponse { traders: vec![] });
+    // no authorized addresses registered
+    let authorized = staking_api.authorized_addresses(account.proxy.addr_str()?, None, None)?;
+    assert_that!(authorized).is_equal_to(api::AuthorizedAddressesResponse { addresses: vec![] });
 
     Ok(())
 }
@@ -234,26 +234,27 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
 // struct TestModule = AppContract
 
 #[test]
-fn not_trader_exec() -> AResult {
+fn unauthorized_exec() -> AResult {
     let sender = Addr::unchecked(OWNER);
-    let not_trader = Addr::unchecked("not_trader");
+    let unauthorized = Addr::unchecked("unauthorized");
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
     let staking_api = init_mock_api(chain, &deployment, None)?;
     install_api(&account.manager, TEST_MODULE_ID)?;
-    // non-trader cannot execute
+    // non-authorized address cannot execute
     let res = staking_api
-        .call_as(&not_trader)
+        .call_as(&unauthorized)
         .execute(&MockExecMsg.into(), None)
         .unwrap_err();
     assert_that!(res.root().to_string()).contains(
-        "Sender: not_trader of request to tester:test-module-id is not a Manager or Trader",
+        "Sender: unauthorized of request to tester:test-module-id is not a Manager or Authorized Address",
     );
     // neither can the ROOT directly
     let res = staking_api.execute(&MockExecMsg.into(), None).unwrap_err();
-    assert_that!(&res.root().to_string())
-        .contains("Sender: owner of request to tester:test-module-id is not a Manager or Trader");
+    assert_that!(&res.root().to_string()).contains(
+        "Sender: owner of request to tester:test-module-id is not a Manager or Authorized Address",
+    );
     Ok(())
 }
 

--- a/contracts/account/manager/tests/apis.rs
+++ b/contracts/account/manager/tests/apis.rs
@@ -55,7 +55,7 @@ fn installing_one_api_should_succeed() -> AResult {
     });
 
     // no traders registered
-    let traders = staking_api.traders(account.proxy.addr_str()?)?;
+    let traders = staking_api.traders(account.proxy.addr_str()?, None, None)?;
     assert_that!(traders).is_equal_to(api::TradersResponse { traders: vec![] });
 
     Ok(())

--- a/contracts/account/manager/tests/upgrades.rs
+++ b/contracts/account/manager/tests/upgrades.rs
@@ -274,7 +274,7 @@ fn uninstall_modules() -> AResult {
 }
 
 #[test]
-fn update_api_with_traders() -> AResult {
+fn update_api_with_authorized_addrs() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let abstr = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse()?)?;
@@ -286,8 +286,12 @@ fn update_api_with_traders() -> AResult {
     let api1 = install_module_version(manager, &abstr, api_1::MOCK_API_ID, V1)?;
     account.expect_modules(vec![api1.clone()])?;
 
-    // register a trader on API1
-    manager.update_api_traders(api_1::MOCK_API_ID, vec!["trader".to_string()], vec![])?;
+    // register a authorized address on API1
+    manager.update_api_authorized_addresses(
+        api_1::MOCK_API_ID,
+        vec!["authorizee".to_string()],
+        vec![],
+    )?;
 
     // upgrade api 1 to version 2
     manager.upgrade_module(
@@ -304,13 +308,13 @@ fn update_api_with_traders() -> AResult {
 
     let api = api_1::BootMockApi1V2::new(chain);
     use abstract_core::api::BaseQueryMsgFns as _;
-    let traders = api.traders(proxy.addr_str()?, None, None)?;
-    assert_that!(traders.traders).contains(Addr::unchecked("trader"));
+    let authorized = api.authorized_addresses(proxy.addr_str()?, None, None)?;
+    assert_that!(authorized.addresses).contains(Addr::unchecked("authorizee"));
 
-    // assert that trader was removed from old API
+    // assert that authorized address was removed from old API
     api.set_address(&Addr::unchecked(api1));
-    let traders = api.traders(proxy.addr_str()?, None, None)?;
-    assert_that!(traders.traders).is_empty();
+    let authorized = api.authorized_addresses(proxy.addr_str()?, None, None)?;
+    assert_that!(authorized.addresses).is_empty();
     Ok(())
 }
 

--- a/contracts/account/manager/tests/upgrades.rs
+++ b/contracts/account/manager/tests/upgrades.rs
@@ -304,12 +304,12 @@ fn update_api_with_traders() -> AResult {
 
     let api = api_1::BootMockApi1V2::new(chain);
     use abstract_core::api::BaseQueryMsgFns as _;
-    let traders = api.traders(proxy.addr_str()?)?;
+    let traders = api.traders(proxy.addr_str()?, None, None)?;
     assert_that!(traders.traders).contains(Addr::unchecked("trader"));
 
     // assert that trader was removed from old API
     api.set_address(&Addr::unchecked(api1));
-    let traders = api.traders(proxy.addr_str()?)?;
+    let traders = api.traders(proxy.addr_str()?, None, None)?;
     assert_that!(traders.traders).is_empty();
     Ok(())
 }

--- a/contracts/account/manager/tests/upgrades.rs
+++ b/contracts/account/manager/tests/upgrades.rs
@@ -308,12 +308,12 @@ fn update_api_with_authorized_addrs() -> AResult {
 
     let api = api_1::BootMockApi1V2::new(chain);
     use abstract_core::api::BaseQueryMsgFns as _;
-    let authorized = api.authorized_addresses(proxy.addr_str()?, None, None)?;
+    let authorized = api.authorized_addresses(proxy.addr_str()?)?;
     assert_that!(authorized.addresses).contains(Addr::unchecked("authorizee"));
 
     // assert that authorized address was removed from old API
     api.set_address(&Addr::unchecked(api1));
-    let authorized = api.authorized_addresses(proxy.addr_str()?, None, None)?;
+    let authorized = api.authorized_addresses(proxy.addr_str()?)?;
     assert_that!(authorized.addresses).is_empty();
     Ok(())
 }

--- a/contracts/ibc-hosts/osmosis/examples/schema.rs
+++ b/contracts/ibc-hosts/osmosis/examples/schema.rs
@@ -1,5 +1,5 @@
 use abstract_sdk::core::{
-    api::{ApiConfigResponse, TradersResponse},
+    api::{ApiConfigResponse, AuthorizedAddressesResponse},
     dex::SimulateSwapResponse,
 };
 use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
@@ -18,7 +18,11 @@ fn main() {
     export_schema_with_title(&schema_for!(SimulateSwapResponse), &out_dir, "ApiResponse");
 
     // export_schema_with_title(&schema_for!(ExecuteMsg<DexRequestMsg>), &out_dir, "ExecuteMsg");
-    export_schema_with_title(&schema_for!(TradersResponse), &out_dir, "TradersResponse");
+    export_schema_with_title(
+        &schema_for!(AuthorizedAddressesResponse),
+        &out_dir,
+        "AuthorizedAddressesResponse",
+    );
     export_schema_with_title(&schema_for!(ApiConfigResponse), &out_dir, "ConfigResponse");
 
     // export_schema_with_title(&schema_for!(ApiQueryMsg), &out_dir, "QueryMsg");

--- a/contracts/native/account-factory/tests/create_account.rs
+++ b/contracts/native/account-factory/tests/create_account.rs
@@ -177,7 +177,7 @@ fn sender_is_not_admin_monarchy() -> AResult {
 
     let account = version_control.account_base(0)?.account_base;
 
-    let account_1 = AbstractAccount::new(chain.clone(), Some(0));
+    let account_1 = AbstractAccount::new(chain, Some(0));
     assert_that!(AccountBase {
         manager: account_1.manager.address()?,
         proxy: account_1.proxy.address()?,

--- a/packages/abstract-api/src/endpoints/execute.rs
+++ b/packages/abstract-api/src/endpoints/execute.rs
@@ -63,8 +63,8 @@ impl<
         message: BaseExecuteMsg,
     ) -> ApiResult {
         match message {
-            BaseExecuteMsg::UpdateTraders { to_add, to_remove } => {
-                self.update_traders(deps, info, to_add, to_remove)
+            BaseExecuteMsg::UpdateAuthorizedAddresses { to_add, to_remove } => {
+                self.update_authorized_addresses(deps, info, to_add, to_remove)
             }
             BaseExecuteMsg::Remove {} => self.remove_self_from_deps(deps.as_ref(), env, info),
         }
@@ -72,7 +72,7 @@ impl<
 
     /// Handle a custom execution message sent to this api.
     /// Two success scenarios are possible:
-    /// 1. The sender is a trader of the given proxy address and has provided the proxy address in the message.
+    /// 1. The sender is an authorized address of the given proxy address and has provided the proxy address in the message.
     /// 2. The sender is a manager of the given proxy address.
     fn handle_app_msg(
         mut self,
@@ -82,7 +82,7 @@ impl<
         request: ApiRequestMsg<CustomExecMsg>,
     ) -> Result<Response, Error> {
         let sender = &info.sender;
-        let unauthorized_sender = |_| ApiError::UnauthorizedTraderApiRequest {
+        let unauthorized_sender = |_| ApiError::UnauthorizedAddressApiRequest {
             api: self.module_id().to_string(),
             sender: sender.to_string(),
         };
@@ -90,23 +90,23 @@ impl<
         let account_registry = self.account_registry(deps.as_ref());
 
         let account_base = match request.proxy_address {
-            // The sender must either be a trader or manager.
+            // The sender must either be an authorized address or manager.
             Some(requested_proxy) => {
                 let proxy_address = deps.api.addr_validate(&requested_proxy)?;
                 let requested_core = account_registry.assert_proxy(&proxy_address)?;
 
-                // Load the traders for the given proxy address.
-                let traders = self
-                    .traders
+                // Load the authorized addresses for the given proxy address.
+                let authorized = self
+                    .authorized_addresses
                     .load(deps.storage, proxy_address)
                     .map_err(Into::into)
                     .map_err(unauthorized_sender)?;
 
-                if traders.contains(sender) {
-                    // If the sender is a trader, return the account_base.
+                if authorized.contains(sender) {
+                    // If the sender is an authorized address, return the account_base.
                     requested_core
                 } else {
-                    // If the sender is NOT a trader, check that it is a manager of some Account.
+                    // If the sender is NOT an authorized address, check that it is a manager of some Account.
                     account_registry
                         .assert_manager(sender)
                         .map_err(unauthorized_sender)?
@@ -142,14 +142,14 @@ impl<
         let modules = self.modules(deps);
         for dep in dependencies {
             let api_addr = modules.module_address(dep.id);
-            // just skip if dep is already removed. This means all the traders are already removed.
+            // just skip if dep is already removed. This means all the authorized addresses are already removed.
             if api_addr.is_err() {
                 continue;
             };
             msgs.push(
                 wasm_execute(
                     api_addr?.into_string(),
-                    &BaseExecuteMsg::UpdateTraders {
+                    &BaseExecuteMsg::UpdateAuthorizedAddresses {
                         to_add: vec![],
                         to_remove: vec![env.contract.address.to_string()],
                     },
@@ -163,8 +163,8 @@ impl<
             .map_err(Into::into)
     }
 
-    /// Remove traders from the api.
-    fn update_traders(
+    /// Remove authorized addresses from the api.
+    fn update_authorized_addresses(
         &self,
         deps: DepsMut,
         info: MessageInfo,
@@ -172,36 +172,45 @@ impl<
         to_remove: Vec<String>,
     ) -> ApiResult {
         let AccountBase {
-            // Manager can only change traders for associated proxy
+            // Manager can only change authorized addresses for associated proxy
             proxy,
             ..
         } = self
             .account_registry(deps.as_ref())
             .assert_manager(&info.sender)?;
 
-        let mut traders = self
-            .traders
+        let mut authorized_addrs = self
+            .authorized_addresses
             .may_load(deps.storage, proxy.clone())?
             .unwrap_or_default();
 
-        // Handle the addition of traders
-        for trader in to_add {
-            let trader_addr = deps.api.addr_validate(trader.as_str())?;
-            if !traders.insert(trader_addr) {
-                return Err(ApiError::TraderAlreadyPresent { trader });
+        // Handle the addition of authorized addresses
+        for new_authorizee in to_add {
+            let authorized_addr = deps.api.addr_validate(new_authorizee.as_str())?;
+            if !authorized_addrs.insert(authorized_addr) {
+                return Err(ApiError::AuthorizedAddressAlreadyPresent {
+                    address: new_authorizee,
+                });
             }
         }
 
-        // Handling the removal of traders
-        for trader in to_remove {
-            let trader_addr = deps.api.addr_validate(trader.as_str())?;
-            if !traders.remove(&trader_addr) {
-                return Err(ApiError::TraderNotPresent { trader });
+        // Handling the removal of authorized addresses
+        for deauthorized in to_remove {
+            let deauthorized_addr = deps.api.addr_validate(deauthorized.as_str())?;
+            if !authorized_addrs.remove(&deauthorized_addr) {
+                return Err(ApiError::AuthorizedAddressNotPresent {
+                    address: deauthorized,
+                });
             }
         }
 
-        self.traders.save(deps.storage, proxy.clone(), &traders)?;
-        Ok(self.custom_tag_response(Response::new(), "update_traders", vec![("proxy", proxy)]))
+        self.authorized_addresses
+            .save(deps.storage, proxy.clone(), &authorized_addrs)?;
+        Ok(self.custom_tag_response(
+            Response::new(),
+            "update_authorized_addresses",
+            vec![("proxy", proxy)],
+        ))
     }
 }
 
@@ -235,101 +244,102 @@ mod tests {
         execute_as(deps, sender, api::ExecuteMsg::Base(msg))
     }
 
-    mod update_traders {
-        use crate::mock::TEST_TRADER;
+    mod update_authorized_addresses {
+        use crate::mock::TEST_AUTHORIZED_ADDRESS;
         use std::collections::BTreeSet;
 
         use super::*;
 
-        fn load_test_proxy_traders(storage: &dyn Storage) -> BTreeSet<Addr> {
+        fn load_test_proxy_authorized_addresses(storage: &dyn Storage) -> BTreeSet<Addr> {
             MOCK_API
-                .traders
+                .authorized_addresses
                 .load(storage, Addr::unchecked(TEST_PROXY))
                 .unwrap()
         }
 
         #[test]
-        fn add_trader() -> ApiMockResult {
+        fn authorize_address() -> ApiMockResult {
             let mut deps = mock_dependencies();
             deps.querier = mock_querier();
 
             mock_init(deps.as_mut())?;
 
             let _api = MOCK_API;
-            let msg = BaseExecuteMsg::UpdateTraders {
-                to_add: vec![TEST_TRADER.into()],
+            let msg = BaseExecuteMsg::UpdateAuthorizedAddresses {
+                to_add: vec![TEST_AUTHORIZED_ADDRESS.into()],
                 to_remove: vec![],
             };
 
             base_execute_as(deps.as_mut(), TEST_MANAGER, msg)?;
 
             let api = MOCK_API;
-            assert_that!(api.traders.is_empty(&deps.storage)).is_false();
+            assert_that!(api.authorized_addresses.is_empty(&deps.storage)).is_false();
 
-            let test_proxy_traders = load_test_proxy_traders(&deps.storage);
+            let test_proxy_authorized_addrs = load_test_proxy_authorized_addresses(&deps.storage);
 
-            assert_that!(test_proxy_traders.len()).is_equal_to(1);
-            assert_that!(test_proxy_traders).contains(Addr::unchecked(TEST_TRADER));
+            assert_that!(test_proxy_authorized_addrs.len()).is_equal_to(1);
+            assert_that!(test_proxy_authorized_addrs)
+                .contains(Addr::unchecked(TEST_AUTHORIZED_ADDRESS));
             Ok(())
         }
 
         #[test]
-        fn remove_trader() -> ApiMockResult {
+        fn revoke_address_authorization() -> ApiMockResult {
             let mut deps = mock_dependencies();
             deps.querier = mock_querier();
 
             mock_init(deps.as_mut())?;
 
             let _api = MOCK_API;
-            let msg = BaseExecuteMsg::UpdateTraders {
-                to_add: vec![TEST_TRADER.into()],
+            let msg = BaseExecuteMsg::UpdateAuthorizedAddresses {
+                to_add: vec![TEST_AUTHORIZED_ADDRESS.into()],
                 to_remove: vec![],
             };
 
             base_execute_as(deps.as_mut(), TEST_MANAGER, msg)?;
 
-            let traders = load_test_proxy_traders(&deps.storage);
-            assert_that!(traders.len()).is_equal_to(1);
+            let authorized_addrs = load_test_proxy_authorized_addresses(&deps.storage);
+            assert_that!(authorized_addrs.len()).is_equal_to(1);
 
-            let msg = BaseExecuteMsg::UpdateTraders {
+            let msg = BaseExecuteMsg::UpdateAuthorizedAddresses {
                 to_add: vec![],
-                to_remove: vec![TEST_TRADER.into()],
+                to_remove: vec![TEST_AUTHORIZED_ADDRESS.into()],
             };
 
             base_execute_as(deps.as_mut(), TEST_MANAGER, msg)?;
-            let traders = load_test_proxy_traders(&deps.storage);
-            assert_that!(traders.len()).is_equal_to(0);
+            let authorized_addrs = load_test_proxy_authorized_addresses(&deps.storage);
+            assert_that!(authorized_addrs.len()).is_equal_to(0);
             Ok(())
         }
 
         #[test]
-        fn add_existing_trader() -> ApiMockResult {
+        fn add_existing_authorized_address() -> ApiMockResult {
             let mut deps = mock_dependencies();
             deps.querier = mock_querier();
 
             mock_init(deps.as_mut())?;
 
             let _api = MOCK_API;
-            let msg = BaseExecuteMsg::UpdateTraders {
-                to_add: vec![TEST_TRADER.into()],
+            let msg = BaseExecuteMsg::UpdateAuthorizedAddresses {
+                to_add: vec![TEST_AUTHORIZED_ADDRESS.into()],
                 to_remove: vec![],
             };
 
             base_execute_as(deps.as_mut(), TEST_MANAGER, msg)?;
 
-            let msg = BaseExecuteMsg::UpdateTraders {
-                to_add: vec![TEST_TRADER.into()],
+            let msg = BaseExecuteMsg::UpdateAuthorizedAddresses {
+                to_add: vec![TEST_AUTHORIZED_ADDRESS.into()],
                 to_remove: vec![],
             };
 
             let res = base_execute_as(deps.as_mut(), TEST_MANAGER, msg);
 
-            let _test_trader_string = TEST_TRADER.to_string();
+            let _test_authorized_address_string = TEST_AUTHORIZED_ADDRESS.to_string();
             assert_that!(res).is_err().matches(|e| {
                 matches!(
                     e,
-                    MockError::Api(ApiError::TraderAlreadyPresent {
-                        trader: _test_trader_string
+                    MockError::Api(ApiError::AuthorizedAddressAlreadyPresent {
+                        address: _test_authorized_address_string
                     })
                 )
             });
@@ -338,26 +348,25 @@ mod tests {
         }
 
         #[test]
-        fn remove_trader_dne() -> ApiMockResult {
+        fn remove_authorized_address_dne() -> ApiMockResult {
             let mut deps = mock_dependencies();
             deps.querier = mock_querier();
 
             mock_init(deps.as_mut())?;
 
             let _api = MOCK_API;
-            let msg = BaseExecuteMsg::UpdateTraders {
+            let msg = BaseExecuteMsg::UpdateAuthorizedAddresses {
                 to_add: vec![],
-                to_remove: vec![TEST_TRADER.into()],
+                to_remove: vec![TEST_AUTHORIZED_ADDRESS.into()],
             };
 
             let res = base_execute_as(deps.as_mut(), TEST_MANAGER, msg);
 
-            let _test_trader_string = TEST_TRADER.to_string();
             assert_that!(res).is_err().matches(|e| {
                 matches!(
                     e,
-                    MockError::Api(ApiError::TraderNotPresent {
-                        trader: _test_trader_string
+                    MockError::Api(ApiError::AuthorizedAddressNotPresent {
+                        address: _test_authorized_address_string
                     })
                 )
             });
@@ -367,24 +376,24 @@ mod tests {
     }
 
     mod execute_app {
-        use crate::mock::{MOCK_API, TEST_TRADER};
+        use crate::mock::{MOCK_API, TEST_AUTHORIZED_ADDRESS};
 
         use super::*;
 
         use abstract_testing::prelude::mocked_account_querier_builder;
 
         /// This sets up the test with the following:
-        /// TEST_PROXY has a single trader, TEST_TRADER
+        /// TEST_PROXY has a single authorized address, test_authorized_address
         /// TEST_MANAGER and TEST_PROXY are the Account base
         ///
         /// Note that the querier needs to mock the Account base, as the proxy will
-        /// query the Account base to get the list of traders.
-        fn setup_with_traders(mut deps: DepsMut, traders: Vec<&str>) {
+        /// query the Account base to get the list of authorized addresses.
+        fn setup_with_authorized_addresses(mut deps: DepsMut, authorized: Vec<&str>) {
             mock_init(deps.branch()).unwrap();
 
             let _api = MOCK_API;
-            let msg = BaseExecuteMsg::UpdateTraders {
-                to_add: traders.into_iter().map(Into::into).collect(),
+            let msg = BaseExecuteMsg::UpdateAuthorizedAddresses {
+                to_add: authorized.into_iter().map(Into::into).collect(),
                 to_remove: vec![],
             };
 
@@ -392,29 +401,29 @@ mod tests {
         }
 
         #[test]
-        fn not_traders_are_unauthorized() {
+        fn unauthorized_addresses_are_unauthorized() {
             let mut deps = mock_dependencies();
             deps.querier = mocked_account_querier_builder().build();
 
-            setup_with_traders(deps.as_mut(), vec![]);
+            setup_with_authorized_addresses(deps.as_mut(), vec![]);
 
             let msg = ExecuteMsg::Module(ApiRequestMsg {
                 proxy_address: None,
                 request: MockExecMsg,
             });
 
-            let not_trader: String = "someoone".into();
-            let res = execute_as(deps.as_mut(), &not_trader, msg);
+            let unauthorized: String = "someoone".into();
+            let res = execute_as(deps.as_mut(), &unauthorized, msg);
 
-            assert_unauthorized(res, not_trader);
+            assert_unauthorized(res, unauthorized);
         }
 
-        fn assert_unauthorized(res: Result<Response, MockError>, _trader: String) {
+        fn assert_unauthorized(res: Result<Response, MockError>, _unauthorized: String) {
             assert_that!(res).is_err().matches(|e| {
                 matches!(
                     e,
-                    MockError::Api(ApiError::UnauthorizedTraderApiRequest {
-                        sender: _trader,
+                    MockError::Api(ApiError::UnauthorizedAddressApiRequest {
+                        sender: _unauthorized,
                         ..
                     })
                 )
@@ -426,7 +435,7 @@ mod tests {
             let mut deps = mock_dependencies();
             deps.querier = mocked_account_querier_builder().build();
 
-            setup_with_traders(deps.as_mut(), vec![]);
+            setup_with_authorized_addresses(deps.as_mut(), vec![]);
 
             let msg = ExecuteMsg::Module(ApiRequestMsg {
                 proxy_address: None,
@@ -439,57 +448,57 @@ mod tests {
         }
 
         #[test]
-        fn executing_as_trader_not_allowed_without_proxy() {
+        fn executing_as_authorized_address_not_allowed_without_proxy() {
             let mut deps = mock_dependencies();
             deps.querier = mocked_account_querier_builder().build();
 
-            setup_with_traders(deps.as_mut(), vec![TEST_TRADER]);
+            setup_with_authorized_addresses(deps.as_mut(), vec![TEST_AUTHORIZED_ADDRESS]);
 
             let msg = ExecuteMsg::Module(ApiRequestMsg {
                 proxy_address: None,
                 request: MockExecMsg,
             });
 
-            let res = execute_as(deps.as_mut(), TEST_TRADER, msg);
+            let res = execute_as(deps.as_mut(), TEST_AUTHORIZED_ADDRESS, msg);
 
-            assert_unauthorized(res, TEST_TRADER.into());
+            assert_unauthorized(res, TEST_AUTHORIZED_ADDRESS.into());
         }
 
         #[test]
-        fn executing_as_trader_is_allowed_via_proxy() {
+        fn executing_as_authorized_address_is_allowed_via_proxy() {
             let mut deps = mock_dependencies();
             deps.querier = mocked_account_querier_builder().build();
 
-            setup_with_traders(deps.as_mut(), vec![TEST_TRADER]);
+            setup_with_authorized_addresses(deps.as_mut(), vec![TEST_AUTHORIZED_ADDRESS]);
 
             let msg = ExecuteMsg::Module(ApiRequestMsg {
                 proxy_address: Some(TEST_PROXY.into()),
                 request: MockExecMsg,
             });
 
-            let res = execute_as(deps.as_mut(), TEST_TRADER, msg);
+            let res = execute_as(deps.as_mut(), TEST_AUTHORIZED_ADDRESS, msg);
 
             assert_that!(res).is_ok();
         }
 
         #[test]
-        fn executing_as_trader_on_diff_proxy_should_err() {
+        fn executing_as_authorized_address_on_diff_proxy_should_err() {
             let other_proxy = "some_other_proxy";
             let mut deps = mock_dependencies();
             deps.querier = mocked_account_querier_builder()
                 .account("some_other_manager", other_proxy, 69420u32)
                 .build();
 
-            setup_with_traders(deps.as_mut(), vec![TEST_TRADER]);
+            setup_with_authorized_addresses(deps.as_mut(), vec![TEST_AUTHORIZED_ADDRESS]);
 
             let msg = ExecuteMsg::Module(ApiRequestMsg {
                 proxy_address: Some(other_proxy.into()),
                 request: MockExecMsg,
             });
 
-            let res = execute_as(deps.as_mut(), TEST_TRADER, msg);
+            let res = execute_as(deps.as_mut(), TEST_AUTHORIZED_ADDRESS, msg);
 
-            assert_unauthorized(res, TEST_TRADER.into());
+            assert_unauthorized(res, TEST_AUTHORIZED_ADDRESS.into());
         }
     }
 }

--- a/packages/abstract-api/src/endpoints/execute.rs
+++ b/packages/abstract-api/src/endpoints/execute.rs
@@ -1,3 +1,4 @@
+use crate::state::MAXIMUM_AUTHORIZED_ADDRESSES;
 use crate::{error::ApiError, state::ApiContract, ApiResult};
 use abstract_core::{
     api::{ApiExecuteMsg, ApiRequestMsg, BaseExecuteMsg, ExecuteMsg},
@@ -45,8 +46,6 @@ impl<
         }
     }
 }
-
-const MAXIMUM_AUTHORIZED_ADDRESSES: u32 = 10;
 
 /// The api-contract base implementation.
 impl<
@@ -258,7 +257,6 @@ mod tests {
 
     mod update_authorized_addresses {
         use crate::mock::TEST_AUTHORIZED_ADDRESS;
-        
 
         use super::*;
 

--- a/packages/abstract-api/src/endpoints/execute.rs
+++ b/packages/abstract-api/src/endpoints/execute.rs
@@ -215,7 +215,6 @@ mod tests {
         testing::{mock_dependencies, mock_env, mock_info},
         Addr, Storage,
     };
-    use std::collections::HashSet;
 
     use crate::mock::*;
     use speculoos::prelude::*;
@@ -238,10 +237,11 @@ mod tests {
 
     mod update_traders {
         use crate::mock::TEST_TRADER;
+        use std::collections::BTreeSet;
 
         use super::*;
 
-        fn load_test_proxy_traders(storage: &dyn Storage) -> HashSet<Addr> {
+        fn load_test_proxy_traders(storage: &dyn Storage) -> BTreeSet<Addr> {
             MOCK_API
                 .traders
                 .load(storage, Addr::unchecked(TEST_PROXY))
@@ -268,7 +268,7 @@ mod tests {
 
             let test_proxy_traders = load_test_proxy_traders(&deps.storage);
 
-            assert_that!(test_proxy_traders).has_length(1);
+            assert_that!(test_proxy_traders.len()).is_equal_to(1);
             assert_that!(test_proxy_traders).contains(Addr::unchecked(TEST_TRADER));
             Ok(())
         }
@@ -289,7 +289,7 @@ mod tests {
             base_execute_as(deps.as_mut(), TEST_MANAGER, msg)?;
 
             let traders = load_test_proxy_traders(&deps.storage);
-            assert_that!(traders).has_length(1);
+            assert_that!(traders.len()).is_equal_to(1);
 
             let msg = BaseExecuteMsg::UpdateTraders {
                 to_add: vec![],
@@ -298,7 +298,7 @@ mod tests {
 
             base_execute_as(deps.as_mut(), TEST_MANAGER, msg)?;
             let traders = load_test_proxy_traders(&deps.storage);
-            assert_that!(traders).is_empty();
+            assert_that!(traders.len()).is_equal_to(0);
             Ok(())
         }
 

--- a/packages/abstract-api/src/endpoints/execute.rs
+++ b/packages/abstract-api/src/endpoints/execute.rs
@@ -209,7 +209,7 @@ impl<
             }
         }
 
-        if authorized_addrs.len() > 10 {
+        if authorized_addrs.len() > MAXIMUM_AUTHORIZED_ADDRESSES as usize {
             return Err(ApiError::TooManyAuthorizedAddresses {
                 max: MAXIMUM_AUTHORIZED_ADDRESSES,
             });

--- a/packages/abstract-api/src/endpoints/instantiate.rs
+++ b/packages/abstract-api/src/endpoints/instantiate.rs
@@ -106,8 +106,8 @@ mod tests {
         });
 
         let api = MOCK_API;
-        let no_traders_registered = api.traders.is_empty(&deps.storage);
-        assert!(no_traders_registered);
+        let none_authorized = api.authorized_addresses.is_empty(&deps.storage);
+        assert!(none_authorized);
 
         let state = api.base_state.load(&deps.storage)?;
         assert_that!(state).is_equal_to(ApiState {

--- a/packages/abstract-api/src/endpoints/query.rs
+++ b/packages/abstract-api/src/endpoints/query.rs
@@ -4,7 +4,11 @@ use abstract_sdk::{
     base::{endpoints::QueryEndpoint, Handler},
     AbstractSdkError,
 };
-use cosmwasm_std::{to_binary, Binary, Deps, Env, StdResult};
+use cosmwasm_std::{to_binary, Addr, Binary, Deps, Env, StdResult};
+use std::collections::{BTreeSet, Bound};
+
+pub(crate) const DEFAULT_LIMIT: u8 = 15;
+pub(crate) const MAX_LIMIT: u8 = 25;
 
 /// Where we dispatch the queries for the ApiContract
 /// These ApiQueryMsg declarations can be found in `abstract_sdk::core::common_module::app_msg`
@@ -39,15 +43,30 @@ impl<
             BaseQueryMsg::Config {} => {
                 to_binary(&self.dapp_config(deps).map_err(Error::from)?).map_err(Into::into)
             }
-            BaseQueryMsg::Traders { proxy_address } => {
-                let traders = self
+            BaseQueryMsg::Traders {
+                proxy_address,
+                limit,
+                start_after,
+            } => {
+                let start_after = start_after
+                    .map(|s| deps.api.addr_validate(&s))
+                    .transpose()?;
+                let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
+
+                let proxy_address = deps.api.addr_validate(&proxy_address)?;
+                let traders: BTreeSet<Addr> = self
                     .traders
-                    .may_load(deps.storage, deps.api.addr_validate(&proxy_address)?)?
+                    .may_load(deps.storage, proxy_address)?
                     .unwrap_or_default();
-                to_binary(&TradersResponse {
-                    traders: traders.into_iter().collect(),
-                })
-                .map_err(Into::into)
+
+                let traders_iter = traders.range((
+                    start_after.map_or(Bound::Unbounded, Bound::Excluded),
+                    Bound::Unbounded,
+                ));
+
+                let traders: Vec<Addr> = traders_iter.take(limit).cloned().collect();
+
+                to_binary(&TradersResponse { traders }).map_err(Into::into)
             }
         }
     }

--- a/packages/abstract-api/src/error.rs
+++ b/packages/abstract-api/src/error.rs
@@ -13,14 +13,14 @@ pub enum ApiError {
     #[error("Sender: {sender} of request to {api} is not a Manager")]
     UnauthorizedApiRequest { api: String, sender: String },
 
-    #[error("Sender: {sender} of request to {api} is not a Manager or Trader")]
-    UnauthorizedTraderApiRequest { api: String, sender: String },
+    #[error("Sender: {sender} of request to {api} is not a Manager or Authorized Address")]
+    UnauthorizedAddressApiRequest { api: String, sender: String },
 
-    #[error("The trader you wished to remove: {} was not present.", trader)]
-    TraderNotPresent { trader: String },
+    #[error("The authorized address to remove: {} was not present.", address)]
+    AuthorizedAddressNotPresent { address: String },
 
-    #[error("The trader you wished to add: {} is already present", trader)]
-    TraderAlreadyPresent { trader: String },
+    #[error("The authorized address to add: {} is already present", address)]
+    AuthorizedAddressAlreadyPresent { address: String },
 
     #[error("This api does not implement any custom queries")]
     NoCustomQueries,

--- a/packages/abstract-api/src/error.rs
+++ b/packages/abstract-api/src/error.rs
@@ -22,6 +22,9 @@ pub enum ApiError {
     #[error("The authorized address to add: {} is already present", address)]
     AuthorizedAddressAlreadyPresent { address: String },
 
+    #[error("Maximum authorized addresses ({}) reached", max)]
+    TooManyAuthorizedAddresses { max: u32 },
+
     #[error("This api does not implement any custom queries")]
     NoCustomQueries,
 

--- a/packages/abstract-api/src/lib.rs
+++ b/packages/abstract-api/src/lib.rs
@@ -34,7 +34,7 @@ pub mod mock {
     use thiserror::Error;
 
     pub const TEST_METADATA: &str = "test_metadata";
-    pub const TEST_TRADER: &str = "test_trader";
+    pub const TEST_AUTHORIZED_ADDRESS: &str = "test_authorized_address";
 
     #[derive(Error, Debug, PartialEq)]
     pub enum MockError {

--- a/packages/abstract-api/src/schema.rs
+++ b/packages/abstract-api/src/schema.rs
@@ -2,7 +2,7 @@ use crate::{ApiContract, ApiError};
 use abstract_core::api::{ApiExecuteMsg, ApiQueryMsg};
 use abstract_sdk::{
     base::endpoints::{ExecuteEndpoint, InstantiateEndpoint, QueryEndpoint},
-    core::api::{ApiConfigResponse, TradersResponse},
+    core::api::{ApiConfigResponse, AuthorizedAddressesResponse},
 };
 use cosmwasm_schema::{export_schema_with_title, schema_for, write_api, QueryResponses};
 use cosmwasm_std::Empty;
@@ -46,7 +46,11 @@ impl<
             out_dir,
             "QueryMsg",
         );
-        export_schema_with_title(&schema_for!(TradersResponse), out_dir, "TradersResponse");
+        export_schema_with_title(
+            &schema_for!(AuthorizedAddressesResponse),
+            out_dir,
+            "AuthorizedAddressesResponse",
+        );
         export_schema_with_title(&schema_for!(ApiConfigResponse), out_dir, "ConfigResponse");
     }
 }

--- a/packages/abstract-api/src/state.rs
+++ b/packages/abstract-api/src/state.rs
@@ -16,7 +16,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeSet, fmt::Debug};
 
-pub const TRADER_NAMESPACE: &str = "traders";
+pub const AUTHORIZED_ADDRS_NAMESPACE: &str = "authorizees";
 
 /// The BaseState contains the main addresses needed for sending and verifying messages
 /// Every DApp should use the provided **ans_host** contract for token/contract address resolution.
@@ -39,8 +39,8 @@ pub struct ApiContract<
     pub(crate) contract:
         AbstractContract<Self, Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Empty, Receive>,
     pub(crate) base_state: Item<'static, ApiState>,
-    /// Map ProxyAddr -> WhitelistedTraders
-    pub traders: Map<'static, Addr, BTreeSet<Addr>>,
+    /// Map ProxyAddr -> AuthorizedAddrs
+    pub authorized_addresses: Map<'static, Addr, BTreeSet<Addr>>,
     /// The Account on which commands are executed. Set each time in the [`abstract_core::api::ExecuteMsg::Base`] handler.
     pub target_account: Option<AccountBase>,
 }
@@ -62,7 +62,7 @@ impl<
         Self {
             contract: AbstractContract::new(name, version, metadata),
             base_state: Item::new(BASE_STATE),
-            traders: Map::new(TRADER_NAMESPACE),
+            authorized_addresses: Map::new(AUTHORIZED_ADDRS_NAMESPACE),
             target_account: None,
         }
     }

--- a/packages/abstract-api/src/state.rs
+++ b/packages/abstract-api/src/state.rs
@@ -14,9 +14,9 @@ use cosmwasm_std::{Addr, Empty, StdError, StdResult, Storage};
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeSet, fmt::Debug};
+use std::fmt::Debug;
 
-pub const AUTHORIZED_ADDRS_NAMESPACE: &str = "authorizees";
+pub const AUTHORIZED_ADDRESSES_NAMESPACE: &str = "authorized_addresses";
 
 /// The BaseState contains the main addresses needed for sending and verifying messages
 /// Every DApp should use the provided **ans_host** contract for token/contract address resolution.
@@ -40,7 +40,7 @@ pub struct ApiContract<
         AbstractContract<Self, Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Empty, Receive>,
     pub(crate) base_state: Item<'static, ApiState>,
     /// Map ProxyAddr -> AuthorizedAddrs
-    pub authorized_addresses: Map<'static, Addr, BTreeSet<Addr>>,
+    pub authorized_addresses: Map<'static, Addr, Vec<Addr>>,
     /// The Account on which commands are executed. Set each time in the [`abstract_core::api::ExecuteMsg::Base`] handler.
     pub target_account: Option<AccountBase>,
 }
@@ -62,7 +62,7 @@ impl<
         Self {
             contract: AbstractContract::new(name, version, metadata),
             base_state: Item::new(BASE_STATE),
-            authorized_addresses: Map::new(AUTHORIZED_ADDRS_NAMESPACE),
+            authorized_addresses: Map::new(AUTHORIZED_ADDRESSES_NAMESPACE),
             target_account: None,
         }
     }

--- a/packages/abstract-api/src/state.rs
+++ b/packages/abstract-api/src/state.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 pub const AUTHORIZED_ADDRESSES_NAMESPACE: &str = "authorized_addresses";
+pub const MAXIMUM_AUTHORIZED_ADDRESSES: u32 = 15;
 
 /// The BaseState contains the main addresses needed for sending and verifying messages
 /// Every DApp should use the provided **ans_host** contract for token/contract address resolution.

--- a/packages/abstract-api/src/state.rs
+++ b/packages/abstract-api/src/state.rs
@@ -14,7 +14,7 @@ use cosmwasm_std::{Addr, Empty, StdError, StdResult, Storage};
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, fmt::Debug};
+use std::{collections::BTreeSet, fmt::Debug};
 
 pub const TRADER_NAMESPACE: &str = "traders";
 
@@ -40,7 +40,7 @@ pub struct ApiContract<
         AbstractContract<Self, Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Empty, Receive>,
     pub(crate) base_state: Item<'static, ApiState>,
     /// Map ProxyAddr -> WhitelistedTraders
-    pub traders: Map<'static, Addr, HashSet<Addr>>,
+    pub traders: Map<'static, Addr, BTreeSet<Addr>>,
     /// The Account on which commands are executed. Set each time in the [`abstract_core::api::ExecuteMsg::Base`] handler.
     pub target_account: Option<AccountBase>,
 }

--- a/packages/abstract-boot/src/account/manager.rs
+++ b/packages/abstract-boot/src/account/manager.rs
@@ -81,7 +81,7 @@ impl<Chain: CwEnv> Manager<Chain> {
         Ok(())
     }
 
-    pub fn update_api_traders(
+    pub fn update_api_authorized_addresses(
         &self,
         module_id: &str,
         to_add: Vec<String>,
@@ -89,7 +89,7 @@ impl<Chain: CwEnv> Manager<Chain> {
     ) -> Result<(), crate::AbstractBootError> {
         self.execute_on_module(
             module_id,
-            api::ExecuteMsg::<Empty, Empty>::Base(api::BaseExecuteMsg::UpdateTraders {
+            api::ExecuteMsg::<Empty, Empty>::Base(api::BaseExecuteMsg::UpdateAuthorizedAddresses {
                 to_add,
                 to_remove,
             }),

--- a/packages/abstract-boot/src/native/account_factory.rs
+++ b/packages/abstract-boot/src/native/account_factory.rs
@@ -6,8 +6,7 @@ use abstract_core::{
     account_factory::*, objects::gov_type::GovernanceDetails, ABSTRACT_EVENT_NAME, MANAGER, PROXY,
 };
 use boot_core::{
-    contract, Contract, CwEnv, IndexResponse, StateInterface, TxResponse,
-    {BootExecute, ContractInstance},
+    contract, Contract, CwEnv, IndexResponse, StateInterface, {BootExecute, ContractInstance},
 };
 use cosmwasm_std::Addr;
 

--- a/packages/abstract-core/src/api.rs
+++ b/packages/abstract-core/src/api.rs
@@ -119,9 +119,12 @@ pub enum BaseQueryMsg {
     #[returns(ApiConfigResponse)]
     Config {},
     /// Returns [`TradersResponse`].
-    /// TODO: enable pagination
     #[returns(TradersResponse)]
-    Traders { proxy_address: String },
+    Traders {
+        proxy_address: String,
+        start_after: Option<String>,
+        limit: Option<u8>,
+    },
 }
 
 impl<T> From<BaseQueryMsg> for QueryMsg<T> {

--- a/packages/abstract-core/src/api.rs
+++ b/packages/abstract-core/src/api.rs
@@ -120,11 +120,7 @@ pub enum BaseQueryMsg {
     Config {},
     /// Returns [`AuthorizedAddressesResponse`].
     #[returns(AuthorizedAddressesResponse)]
-    AuthorizedAddresses {
-        proxy_address: String,
-        start_after: Option<String>,
-        limit: Option<u8>,
-    },
+    AuthorizedAddresses { proxy_address: String },
 }
 
 impl<T> From<BaseQueryMsg> for QueryMsg<T> {

--- a/packages/abstract-core/src/api.rs
+++ b/packages/abstract-core/src/api.rs
@@ -99,9 +99,9 @@ impl<Request: Serialize> ApiRequestMsg<Request> {
 #[cfg_attr(feature = "boot", derive(boot_core::ExecuteFns))]
 #[cfg_attr(feature = "boot", impl_into(ExecuteMsg<T>))]
 pub enum BaseExecuteMsg {
-    /// Add or remove traders
-    /// If a trader is both in to_add and to_remove, it will be removed.
-    UpdateTraders {
+    /// Add or remove authorized addresses
+    /// If an authorized address is both in to_add and to_remove, it will be removed.
+    UpdateAuthorizedAddresses {
         to_add: Vec<String>,
         to_remove: Vec<String>,
     },
@@ -118,9 +118,9 @@ pub enum BaseQueryMsg {
     /// Returns [`ApiConfigResponse`].
     #[returns(ApiConfigResponse)]
     Config {},
-    /// Returns [`TradersResponse`].
-    #[returns(TradersResponse)]
-    Traders {
+    /// Returns [`AuthorizedAddressesResponse`].
+    #[returns(AuthorizedAddressesResponse)]
+    AuthorizedAddresses {
         proxy_address: String,
         start_after: Option<String>,
         limit: Option<u8>,
@@ -140,7 +140,7 @@ pub struct ApiConfigResponse {
 }
 
 #[cosmwasm_schema::cw_serde]
-pub struct TradersResponse {
-    /// Contains all traders
-    pub traders: Vec<Addr>,
+pub struct AuthorizedAddressesResponse {
+    /// Contains all authorized addresses
+    pub addresses: Vec<Addr>,
 }

--- a/packages/abstract-ibc-host/src/state.rs
+++ b/packages/abstract-ibc-host/src/state.rs
@@ -20,8 +20,6 @@ use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-pub const TRADER_NAMESPACE: &str = "traders";
-
 /// Store channel information for proxy contract creation reply
 pub const PENDING: Item<(String, AccountId)> = Item::new("pending");
 /// Store the processing packet information for processing in Reply along with the channel id it came from

--- a/packages/abstract-sdk/src/apis/bank.rs
+++ b/packages/abstract-sdk/src/apis/bank.rs
@@ -38,7 +38,7 @@ impl<'a, T: TransferInterface> Bank<'a, T> {
     }
 
     /// Transfer the provided **funds** from the Account' vault to the **recipient**.
-    /// The caller must be a whitelisted module or trader.
+    /// The caller must be a whitelisted module or authorized address.
     /// ```rust
     /// # use cosmwasm_std::{Addr, Response, Deps, DepsMut, MessageInfo};
     /// # use abstract_core::objects::AnsAsset;


### PR DESCRIPTION
This change limits the number of authorized addresses to 15. This fixes the issue with gas limitations for the `Config` and `AuthorizedAddresses` queries.

It also renames "traders" to "authorized addresses".
