### PR TITLE
Provider to namespace

### DIFF
--- a/contracts/account/manager/src/commands.rs
+++ b/contracts/account/manager/src/commands.rs
@@ -764,9 +764,7 @@ mod test {
             let new_gov = "new_gov".to_string();
 
             let msg = ExecuteMsg::SetOwner {
-                owner: GovernanceDetails::Monarchy {
-                    monarch: new_gov.to_string(),
-                },
+                owner: GovernanceDetails::Monarchy { monarch: new_gov },
             };
 
             execute_as_owner(deps.as_mut(), msg)?;

--- a/contracts/native/ans-host/src/commands.rs
+++ b/contracts/native/ans-host/src/commands.rs
@@ -556,23 +556,23 @@ mod test {
 
         use super::*;
 
-        fn contract_entry(provider: &str, name: &str) -> UncheckedContractEntry {
+        fn contract_entry(namespace: &str, name: &str) -> UncheckedContractEntry {
             UncheckedContractEntry {
-                protocol: provider.to_string(),
+                protocol: namespace.to_string(),
                 contract: name.to_string(),
             }
         }
 
         fn contract_address_map_entry(
-            provider: &str,
+            namespace: &str,
             name: &str,
             address: &str,
         ) -> (UncheckedContractEntry, String) {
-            (contract_entry(provider, name), address.to_string())
+            (contract_entry(namespace, name), address.to_string())
         }
 
         fn mock_contract_map_entry() -> (UncheckedContractEntry, String) {
-            contract_address_map_entry("test_provider", "test_contract", "test_address")
+            contract_address_map_entry("test_namespace", "test_contract", "test_address")
         }
 
         fn update_contract_addresses_msg_builder(
@@ -668,11 +668,11 @@ mod test {
             let mut map_tester = setup_map_tester();
 
             let new_entry_1 =
-                contract_address_map_entry("test_provider", "test_contract", "test_address");
+                contract_address_map_entry("test_namespace", "test_contract", "test_address");
             let new_entry_2 =
-                contract_address_map_entry("test_provider_2", "test_contract_2", "test_address_2");
+                contract_address_map_entry("test_namespace_2", "test_contract_2", "test_address_2");
             let new_entry_3 =
-                contract_address_map_entry("test_provider_3", "test_contract_3", "test_address_3");
+                contract_address_map_entry("test_namespace_3", "test_contract_3", "test_address_3");
 
             map_tester.test_update_auto_expect(
                 &mut deps,
@@ -688,9 +688,9 @@ mod test {
 
             let _info = mock_info(TEST_CREATOR, &[]);
             let new_entry_1 =
-                contract_address_map_entry("test_provider", "test_contract", "test_address");
+                contract_address_map_entry("test_namespace", "test_contract", "test_address");
             let new_entry_2 =
-                contract_address_map_entry("test_provider_2", "test_contract_2", "test_address_2");
+                contract_address_map_entry("test_namespace_2", "test_contract_2", "test_address_2");
 
             // add 1 and 2
             map_tester.test_update_auto_expect(
@@ -699,7 +699,7 @@ mod test {
             )?;
 
             let new_entry_3 =
-                contract_address_map_entry("test_provider_3", "test_contract_3", "test_address_3");
+                contract_address_map_entry("test_namespace_3", "test_contract_3", "test_address_3");
 
             // Add 3 and remove 1, leaving 2 and 3
             map_tester.test_update_with_expected(
@@ -716,7 +716,7 @@ mod test {
             let mut map_tester = setup_map_tester();
 
             let bad_entry =
-                contract_address_map_entry("test_provider", "test_contract", "BAD_ADDRESS");
+                contract_address_map_entry("test_namespace", "test_contract", "BAD_ADDRESS");
 
             let res = map_tester.execute_update(deps.as_mut(), (vec![bad_entry], vec![]));
 
@@ -966,12 +966,21 @@ mod test {
             UncheckedChannelMapEntry,
             UncheckedChannelMapEntry,
         ) {
-            let new_entry_1 =
-                unchecked_channel_map_entry("test_provider_1", "test_contract_1", "test_address_1");
-            let new_entry_2 =
-                unchecked_channel_map_entry("test_provider_2", "test_contract_2", "test_address_2");
-            let new_entry_3 =
-                unchecked_channel_map_entry("test_provider_3", "test_contract_3", "test_address_3");
+            let new_entry_1 = unchecked_channel_map_entry(
+                "test_namespace_1",
+                "test_contract_1",
+                "test_address_1",
+            );
+            let new_entry_2 = unchecked_channel_map_entry(
+                "test_namespace_2",
+                "test_contract_2",
+                "test_address_2",
+            );
+            let new_entry_3 = unchecked_channel_map_entry(
+                "test_namespace_3",
+                "test_contract_3",
+                "test_address_3",
+            );
             (new_entry_1, new_entry_2, new_entry_3)
         }
 
@@ -1072,8 +1081,11 @@ mod test {
                 (vec![new_entry_1.clone(), new_entry_2.clone()], vec![]),
             )?;
 
-            let new_entry_3 =
-                unchecked_channel_map_entry("test_provider_3", "test_contract_3", "test_address_3");
+            let new_entry_3 = unchecked_channel_map_entry(
+                "test_namespace_3",
+                "test_contract_3",
+                "test_address_3",
+            );
 
             // Add 3 and remove 1, leaving 2 and 3
             map_tester.test_update_with_expected(

--- a/contracts/native/version-control/src/commands.rs
+++ b/contracts/native/version-control/src/commands.rs
@@ -49,7 +49,7 @@ pub fn add_modules(
         // version must be set in order to add the new version
         module.assert_version_variant()?;
 
-        if module.provider == ABSTRACT_NAMESPACE {
+        if module.namespace == ABSTRACT_NAMESPACE {
             // Only Admin can update abstract contracts
             ADMIN.assert_admin(deps.as_ref(), &msg_info.sender)?;
         }
@@ -106,7 +106,7 @@ mod test {
     type VersionControlTestResult = Result<(), VCError>;
 
     const TEST_OTHER: &str = "test-other";
-    const TEST_MODULE: &str = "provider:test";
+    const TEST_MODULE: &str = "namespace:test";
 
     const TEST_PROXY_ADDR: &str = "proxy";
     const TEST_MANAGER_ADDR: &str = "manager";
@@ -326,22 +326,22 @@ mod test {
                 ModuleInfo {
                     name: "test-module".to_string(),
                     version: ModuleVersion::Version("0.0.1".to_string()),
-                    provider: "".to_string(),
+                    namespace: "".to_string(),
                 },
                 ModuleInfo {
                     name: "test-module".to_string(),
                     version: ModuleVersion::Version("0.0.1".to_string()),
-                    provider: "".to_string(),
+                    namespace: "".to_string(),
                 },
                 ModuleInfo {
                     name: "".to_string(),
                     version: ModuleVersion::Version("0.0.1".to_string()),
-                    provider: "test".to_string(),
+                    namespace: "test".to_string(),
                 },
                 ModuleInfo {
                     name: "test-module".to_string(),
                     version: ModuleVersion::Version("aoeu".to_string()),
-                    provider: "".to_string(),
+                    namespace: "".to_string(),
                 },
             ];
 

--- a/contracts/testing/src/tests/module_factory.rs
+++ b/contracts/testing/src/tests/module_factory.rs
@@ -65,7 +65,7 @@ fn proper_initialization() {
                 },
                 deposit_asset: "test".into(),
                 fee: Decimal::from_str("0.91").unwrap(),
-                provider_addr: sender.to_string(),
+                namespace_addr: sender.to_string(),
                 token_code_id: env.code_ids.get(CW20).unwrap().clone(),
                 vault_lp_token_name: None,
                 vault_lp_token_symbol: None,

--- a/packages/abstract-core/src/native/version_control.rs
+++ b/packages/abstract-core/src/native/version_control.rs
@@ -71,7 +71,7 @@ pub enum ExecuteMsg {
 #[derive(Default)]
 #[cosmwasm_schema::cw_serde]
 pub struct ModuleFilter {
-    pub provider: Option<String>,
+    pub namespace: Option<String>,
     pub name: Option<String>,
     pub version: Option<String>,
 }

--- a/scripts/src/bin/fix_names.rs
+++ b/scripts/src/bin/fix_names.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 
 const NETWORK: NetworkInfo = PISCO_1;
-const PROVIDER: &str = "abstract";
+const NAMESPACE: &str = "abstract";
 
 /// Script that takes existing versions in Version control, removes them, and swaps them wit ha new version
 pub fn fix_names() -> anyhow::Result<()> {
@@ -29,14 +29,14 @@ pub fn fix_names() -> anyhow::Result<()> {
         let ModuleInfo {
             version,
             name,
-            provider,
+            namespace,
         } = info.clone();
-        if provider == PROVIDER && name.to_string().contains('_') {
+        if namespace == NAMESPACE && name.to_string().contains('_') {
             deployment.version_control.remove_module(info)?;
             deployment.version_control.add_modules(vec![(
                 ModuleInfo {
                     name: name.replace('_', "-"),
-                    provider,
+                    namespace,
                     version,
                 },
                 reference,

--- a/scripts/src/bin/fix_versions.rs
+++ b/scripts/src/bin/fix_versions.rs
@@ -14,7 +14,7 @@ use tokio::runtime::Runtime;
 const NETWORK: NetworkInfo = UNI_6;
 const WRONG_VERSION: &str = "0.1.0-rc.3";
 const NEW_VERSION: &str = env!("CARGO_PKG_VERSION");
-const PROVIDER: &str = "abstract";
+const NAMESPACE: &str = "abstract";
 
 /// Script that takes existing versions in Version control, removes them, and swaps them wit ha new version
 pub fn fix_versions() -> anyhow::Result<()> {
@@ -26,7 +26,7 @@ pub fn fix_versions() -> anyhow::Result<()> {
 
     let ModulesListResponse { modules } = deployment.version_control.module_list(
         Some(ModuleFilter {
-            provider: Some(PROVIDER.to_string()),
+            namespace: Some(NAMESPACE.to_string()),
             version: Some(WRONG_VERSION.to_string()),
             ..Default::default()
         }),
@@ -38,14 +38,14 @@ pub fn fix_versions() -> anyhow::Result<()> {
         let ModuleInfo {
             version,
             name,
-            provider,
+            namespace,
         } = info.clone();
-        if version.to_string() == *WRONG_VERSION && provider == *PROVIDER {
+        if version.to_string() == *WRONG_VERSION && namespace == *NAMESPACE {
             deployment.version_control.remove_module(info)?;
             deployment.version_control.add_modules(vec![(
                 ModuleInfo {
                     name,
-                    provider,
+                    namespace,
                     version: ModuleVersion::from(NEW_VERSION),
                 },
                 reference,

--- a/scripts/src/bin/remove_version.rs
+++ b/scripts/src/bin/remove_version.rs
@@ -30,7 +30,7 @@ pub fn deploy_api() -> anyhow::Result<()> {
     for version in old_versions {
         let res = version_control.remove_module(ModuleInfo {
             name: "autocompounder".to_string(),
-            provider: "4t2".into(),
+            namespace: "4t2".into(),
             version: ModuleVersion::from(version),
         });
 
@@ -40,7 +40,7 @@ pub fn deploy_api() -> anyhow::Result<()> {
 
         let res = version_control.remove_module(ModuleInfo {
             name: "cw_staking".to_string(),
-            provider: "4t2".into(),
+            namespace: "4t2".into(),
             version: ModuleVersion::from(version),
         });
 


### PR DESCRIPTION
this change makes the use of `namespace` consistent across our contracts. This is the namespace for the module providers.