### PR TITLE
Prefix cw-ownable calls with the crate

### DIFF
--- a/contracts/native/account-factory/src/commands.rs
+++ b/contracts/native/account-factory/src/commands.rs
@@ -18,7 +18,6 @@ use cosmwasm_std::{
     to_binary, wasm_execute, Addr, CosmosMsg, DepsMut, Empty, Env, MessageInfo, QuerierWrapper,
     ReplyOn, StdError, SubMsg, SubMsgResult, WasmMsg,
 };
-use cw_ownable::assert_owner;
 
 use protobuf::Message;
 
@@ -230,7 +229,7 @@ pub fn execute_update_config(
     version_control_contract: Option<String>,
     module_factory_address: Option<String>,
 ) -> AccountFactoryResult {
-    assert_owner(deps.storage, &info.sender)?;
+    cw_ownable::assert_owner(deps.storage, &info.sender)?;
 
     let mut config: Config = CONFIG.load(deps.storage)?;
 

--- a/contracts/native/account-factory/src/error.rs
+++ b/contracts/native/account-factory/src/error.rs
@@ -3,7 +3,6 @@ use abstract_sdk::AbstractSdkError;
 use cosmwasm_std::StdError;
 use cw_asset::AssetError;
 use cw_controllers::AdminError;
-use cw_ownable::OwnershipError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -21,7 +20,7 @@ pub enum AccountFactoryError {
     Asset(#[from] AssetError),
 
     #[error("{0}")]
-    Ownership(#[from] OwnershipError),
+    Ownership(#[from] cw_ownable::OwnershipError),
 
     #[error("{0}")]
     Admin(#[from] AdminError),

--- a/contracts/native/ans-host/src/commands.rs
+++ b/contracts/native/ans-host/src/commands.rs
@@ -17,7 +17,6 @@ use abstract_macros::abstract_response;
 use abstract_sdk::execute_update_ownership;
 use cosmwasm_std::{Addr, DepsMut, Env, MessageInfo, StdError, StdResult, Storage};
 use cw_asset::AssetInfoUnchecked;
-use cw_ownable::assert_owner;
 
 const MIN_POOL_ASSETS: usize = 2;
 const MAX_POOL_ASSETS: usize = 5;
@@ -66,7 +65,7 @@ pub fn update_contract_addresses(
     to_remove: Vec<UncheckedContractEntry>,
 ) -> AnsHostResult {
     // Only Admin can call this method
-    assert_owner(deps.storage, &msg_info.sender)?;
+    cw_ownable::assert_owner(deps.storage, &msg_info.sender)?;
 
     for (key, new_address) in to_add.into_iter() {
         let key = key.check();
@@ -94,7 +93,7 @@ pub fn update_asset_addresses(
     to_remove: Vec<String>,
 ) -> AnsHostResult {
     // Only Admin can call this method
-    assert_owner(deps.storage, &msg_info.sender)?;
+    cw_ownable::assert_owner(deps.storage, &msg_info.sender)?;
 
     for (name, new_asset) in to_add.into_iter() {
         // validate asset
@@ -126,7 +125,7 @@ pub fn update_channels(
     to_remove: Vec<UncheckedChannelEntry>,
 ) -> AnsHostResult {
     // Only Admin can call this method
-    assert_owner(deps.storage, &msg_info.sender)?;
+    cw_ownable::assert_owner(deps.storage, &msg_info.sender)?;
 
     for (key, new_channel) in to_add.into_iter() {
         let key = key.check();
@@ -151,7 +150,7 @@ fn update_dex_registry(
     to_remove: Vec<String>,
 ) -> AnsHostResult {
     // Only Admin can call this method
-    assert_owner(deps.storage, &msg_info.sender)?;
+    cw_ownable::assert_owner(deps.storage, &msg_info.sender)?;
 
     if !to_add.is_empty() {
         let register_dex = |mut dexes: Vec<String>| -> StdResult<Vec<String>> {
@@ -186,7 +185,7 @@ fn update_pools(
     to_remove: Vec<UniquePoolId>,
 ) -> AnsHostResult {
     // Only Admin can call this method
-    assert_owner(deps.storage, &msg_info.sender)?;
+    cw_ownable::assert_owner(deps.storage, &msg_info.sender)?;
 
     let original_unique_pool_id = CONFIG.load(deps.storage)?.next_unique_pool_id;
     let mut next_unique_pool_id = original_unique_pool_id;

--- a/contracts/native/ans-host/src/contract.rs
+++ b/contracts/native/ans-host/src/contract.rs
@@ -11,7 +11,6 @@ use abstract_core::{
 };
 use cosmwasm_std::{Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw2::{get_contract_version, set_contract_version};
-use cw_ownable::initialize_owner;
 use semver::Version;
 
 pub type AnsHostResult = Result<Response, AnsHostError>;
@@ -48,7 +47,7 @@ pub fn instantiate(
     REGISTERED_DEXES.save(deps.storage, &vec![])?;
 
     // Setup the admin as the creator of the contract
-    initialize_owner(deps.storage, deps.api, Some(info.sender.as_str()))?;
+    cw_ownable::initialize_owner(deps.storage, deps.api, Some(info.sender.as_str()))?;
 
     Ok(Response::default())
 }

--- a/contracts/native/ans-host/src/error.rs
+++ b/contracts/native/ans-host/src/error.rs
@@ -2,7 +2,6 @@ use abstract_core::AbstractError;
 use abstract_sdk::AbstractSdkError;
 use cosmwasm_std::StdError;
 use cw_asset::AssetError;
-use cw_ownable::OwnershipError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -20,7 +19,7 @@ pub enum AnsHostError {
     Asset(#[from] AssetError),
 
     #[error("{0}")]
-    Ownership(#[from] OwnershipError),
+    Ownership(#[from] cw_ownable::OwnershipError),
 
     #[error("You must provide exactly two assets when adding liquidity")]
     NotTwoAssets {},

--- a/contracts/native/ans-host/src/queries.rs
+++ b/contracts/native/ans-host/src/queries.rs
@@ -19,7 +19,6 @@ use abstract_core::{
 use abstract_sdk::cw_helpers::cw_storage_plus::load_many;
 use cosmwasm_std::{to_binary, Binary, Deps, Env, Order, StdError, StdResult, Storage};
 use cw_asset::AssetInfoUnchecked;
-use cw_ownable::{get_ownership, Ownership};
 use cw_storage_plus::Bound;
 
 pub(crate) const DEFAULT_LIMIT: u8 = 15;
@@ -30,7 +29,7 @@ pub fn query_config(deps: Deps) -> StdResult<Binary> {
         next_unique_pool_id,
     } = CONFIG.load(deps.storage)?;
 
-    let Ownership { owner, .. } = get_ownership(deps.storage)?;
+    let cw_ownable::Ownership { owner, .. } = cw_ownable::get_ownership(deps.storage)?;
 
     let res = ConfigResponse {
         next_unique_pool_id,

--- a/contracts/native/ans-host/src/tests/instantiate.rs
+++ b/contracts/native/ans-host/src/tests/instantiate.rs
@@ -4,7 +4,6 @@ use crate::tests::mock_querier::mock_dependencies;
 use abstract_core::ans_host::*;
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::{Addr, DepsMut};
-use cw_ownable::get_ownership;
 use speculoos::prelude::*;
 
 pub(crate) fn instantiate_msg() -> InstantiateMsg {
@@ -55,7 +54,7 @@ fn successful_update_ownership() {
     let accept_res = execute_as(deps.as_mut(), new_admin, accept_msg).unwrap();
     assert_eq!(0, accept_res.messages.len());
 
-    assert_that!(get_ownership(&deps.storage).unwrap().owner)
+    assert_that!(cw_ownable::get_ownership(&deps.storage).unwrap().owner)
         .is_some()
         .is_equal_to(Addr::unchecked(new_admin))
 }

--- a/contracts/native/version-control/src/commands.rs
+++ b/contracts/native/version-control/src/commands.rs
@@ -8,7 +8,6 @@ use abstract_sdk::core::{
     VERSION_CONTROL,
 };
 use cosmwasm_std::{DepsMut, MessageInfo, Response};
-use cw_ownable::assert_owner;
 
 #[abstract_response(VERSION_CONTROL)]
 pub struct VcResponse;
@@ -52,7 +51,7 @@ pub fn add_modules(
 
         if module.namespace == ABSTRACT_NAMESPACE {
             // Only Admin can update abstract contracts
-            assert_owner(deps.storage, &msg_info.sender)?;
+            cw_ownable::assert_owner(deps.storage, &msg_info.sender)?;
         }
         MODULE_LIBRARY.save(deps.storage, &module, &mod_ref)?;
     }
@@ -63,7 +62,7 @@ pub fn add_modules(
 /// Remove a module
 pub fn remove_module(deps: DepsMut, msg_info: MessageInfo, module: ModuleInfo) -> VCResult {
     // Only Admin can update code-ids
-    assert_owner(deps.storage, &msg_info.sender)?;
+    cw_ownable::assert_owner(deps.storage, &msg_info.sender)?;
     module.assert_version_variant()?;
     if MODULE_LIBRARY.has(deps.storage, &module) {
         MODULE_LIBRARY.remove(deps.storage, &module);
@@ -455,7 +454,7 @@ mod test {
 }
 
 pub fn set_factory(deps: DepsMut, info: MessageInfo, new_admin: String) -> VCResult {
-    assert_owner(deps.storage, &info.sender)?;
+    cw_ownable::assert_owner(deps.storage, &info.sender)?;
 
     let new_factory_addr = deps.api.addr_validate(&new_admin)?;
     FACTORY.set(deps, Some(new_factory_addr))?;

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -9,11 +9,11 @@ use abstract_sdk::core::{
 use abstract_sdk::{execute_update_ownership, query_ownership};
 use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw2::{get_contract_version, set_contract_version};
-use cw_controllers::{Admin, AdminError};
-use cw_ownable::{assert_owner, get_ownership, initialize_owner, Ownership};
+
 use cw_semver::Version;
 
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 use crate::commands::*;
 use crate::queries;
 
@@ -49,8 +49,8 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, _msg: Instantiat
         None::<String>,
     )?;
 
-    // Setup the admin as the creator of the contract
-    initialize_owner(deps.storage, deps.api, Some(info.sender.as_str()))?;
+    // Set up the admin as the creator of the contract
+    cw_ownable::initialize_owner(deps.storage, deps.api, Some(info.sender.as_str()))?;
 
     FACTORY.set(deps, None)?;
 
@@ -81,7 +81,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::Modules { infos } => queries::handle_modules_query(deps, infos),
         QueryMsg::Config {} => {
-            let Ownership { owner, .. } = get_ownership(deps.storage)?;
+            let cw_ownable::Ownership { owner, .. } = cw_ownable::get_ownership(deps.storage)?;
 
             let factory = FACTORY.get(deps)?.unwrap();
             to_binary(&ConfigResponse {

--- a/contracts/native/version-control/src/error.rs
+++ b/contracts/native/version-control/src/error.rs
@@ -2,7 +2,6 @@ use abstract_core::{objects::AccountId, AbstractError};
 use abstract_sdk::{core::objects::module::ModuleInfo, AbstractSdkError};
 use cosmwasm_std::StdError;
 use cw_controllers::AdminError;
-use cw_ownable::OwnershipError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
@@ -20,7 +19,7 @@ pub enum VCError {
     Admin(#[from] AdminError),
 
     #[error("{0}")]
-    Ownership(#[from] OwnershipError),
+    Ownership(#[from] cw_ownable::OwnershipError),
 
     #[error("Semver parsing error: {0}")]
     SemVer(String),

--- a/packages/abstract-sdk/src/cw_helpers/cw_ownable.rs
+++ b/packages/abstract-sdk/src/cw_helpers/cw_ownable.rs
@@ -49,7 +49,7 @@ mod tests {
         Addr, Binary, StdError, StdResult,
     };
 
-    use cw_ownable::{cw_ownable_execute, cw_ownable_query, Action, Ownership, OwnershipError};
+    use cw_ownable::{cw_ownable_execute, cw_ownable_query, Action, OwnershipError};
     use thiserror::Error;
 
     const MOCK_CONTRACT: &str = "contract";
@@ -71,7 +71,7 @@ mod tests {
         #[error("{0}")]
         Std(#[from] StdError),
         #[error("{0}")]
-        Ownership(#[from] OwnershipError),
+        Ownership(#[from] cw_ownable::OwnershipError),
     }
 
     const NEW_OWNER: &str = "new_owner";
@@ -132,14 +132,14 @@ mod tests {
             QueryMsg::Ownership {} => query_ownership!(deps.as_ref()),
         };
 
-        let expected = Ownership {
+        let expected = cw_ownable::Ownership {
             owner: Some(Addr::unchecked(old_owner)),
             pending_owner: None,
             pending_expiry: None,
         };
 
         // Deserialize the query response
-        let actual: Ownership<Addr> = from_binary(&result.unwrap())?;
+        let actual: cw_ownable::Ownership<Addr> = from_binary(&result.unwrap())?;
 
         assert_eq!(actual, expected);
 


### PR DESCRIPTION
This change prefixes each of the cw-ownable calls with the crate name for better clarity.