### PR TITLE
Use cw-ownable in the proxy

### DIFF
--- a/contracts/account/manager/Cargo.toml
+++ b/contracts/account/manager/Cargo.toml
@@ -35,6 +35,7 @@ abstract-core = { workspace = true }
 semver = { workspace = true }
 cw-semver = { workspace = true }
 abstract-macros = { workspace = true }
+cw-ownable = { workspace = true }
 
 [dev-dependencies]
 cw20 = { workspace = true }

--- a/contracts/account/manager/src/contract.rs
+++ b/contracts/account/manager/src/contract.rs
@@ -100,6 +100,9 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> M
         ExecuteMsg::UpdateStatus {
             is_suspended: suspension_status,
         } => update_account_status(deps, info, suspension_status),
+        ExecuteMsg::AcceptProxyOwnership { proxy_address } => {
+            accept_proxy_ownership(deps, info, &proxy_address)
+        }
         msg => {
             // Block actions if user is not subscribed
             let is_suspended = SUSPENSION_STATUS.load(deps.storage)?;

--- a/contracts/account/manager/src/error.rs
+++ b/contracts/account/manager/src/error.rs
@@ -1,3 +1,4 @@
+use abstract_core::objects::AccountId;
 use abstract_core::AbstractError;
 use abstract_sdk::core::objects::module::ModuleInfo;
 use abstract_sdk::AbstractSdkError;
@@ -32,7 +33,10 @@ pub enum ManagerError {
     InvalidModuleName {},
 
     #[error("Registering module fails because caller is not module factory")]
-    CallerNotFactory {},
+    CallerNotModuleFactory {},
+
+    #[error("Caller is not account factory.")]
+    CallerNotAccountFactory {},
 
     #[error("A migratemsg is required when when migrating this module")]
     MsgRequired {},
@@ -86,4 +90,16 @@ pub enum ManagerError {
 
     #[error("No updates were included")]
     NoUpdates {},
+
+    #[error(
+        "Unknown proxy {} with account_id: {}, manager_account_id: {}",
+        proxy,
+        proxy_account_id,
+        manager_account_id
+    )]
+    UnknownProxy {
+        proxy: String,
+        proxy_account_id: AccountId,
+        manager_account_id: AccountId,
+    },
 }

--- a/contracts/account/manager/tests/apis.rs
+++ b/contracts/account/manager/tests/apis.rs
@@ -5,7 +5,7 @@ use abstract_boot::*;
 use abstract_core::manager::ManagerModuleInfo;
 use abstract_core::objects::module::{ModuleInfo, ModuleVersion};
 use abstract_core::{api::BaseQueryMsgFns, *};
-use abstract_testing::prelude::{OWNER, TEST_MODULE_ID, TEST_VERSION};
+use abstract_testing::prelude::{TEST_MODULE_ID, TEST_VERSION};
 use boot_core::{
     BootError, Mock, {instantiate_default_mock_env, CallAs, ContractInstance},
 };
@@ -235,7 +235,7 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
 
 #[test]
 fn unauthorized_exec() -> AResult {
-    let sender = Addr::unchecked(OWNER);
+    let sender = Addr::unchecked("owner");
     let unauthorized = Addr::unchecked("unauthorized");
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;

--- a/contracts/account/proxy/Cargo.toml
+++ b/contracts/account/proxy/Cargo.toml
@@ -35,6 +35,7 @@ semver = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 abstract-macros = { workspace = true }
+cw-ownable = { workspace = true }
 
 [dev-dependencies]
 cw20 = { workspace = true }

--- a/contracts/account/proxy/src/error.rs
+++ b/contracts/account/proxy/src/error.rs
@@ -18,17 +18,20 @@ pub enum ProxyError {
     #[error("{0}")]
     Asset(#[from] AssetError),
 
+    #[error("{0}")]
+    Ownership(#[from] cw_ownable::OwnershipError),
+
     #[error(transparent)]
     Admin(#[from] ::cw_controllers::AdminError),
 
-    #[error("Module with address {0} is already whitelisted")]
-    AlreadyWhitelisted(String),
+    #[error("Module with address {0} is already allowlisted")]
+    AlreadyAllowlisted(String),
 
-    #[error("Module with address {0} not found in whitelist")]
-    NotWhitelisted(String),
+    #[error("Module with address {0} not found in allowlist")]
+    ModuleNotAllowlisted(String),
 
-    #[error("Sender is not whitelisted")]
-    SenderNotWhitelisted {},
+    #[error("Sender is not allowlisted")]
+    SenderNotAllowlisted {},
 
     #[error("Max amount of assets registered")]
     AssetsLimitReached,

--- a/packages/abstract-boot/src/account/mod.rs
+++ b/packages/abstract-boot/src/account/mod.rs
@@ -86,9 +86,9 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
 
         Ok(manager_modules)
     }
-    /// Checks that the proxy's whitelist includes the expected module addresses.
+    /// Checks that the proxy's module list includes the expected module addresses.
     /// Automatically includes the manager in the expected whitelist.
-    pub fn expect_whitelist(
+    pub fn expect_module_list(
         &self,
         whitelisted_addrs: Vec<String>,
     ) -> Result<Vec<String>, crate::AbstractBootError> {
@@ -101,6 +101,7 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
         // check proxy config
         let abstract_core::proxy::ConfigResponse {
             modules: proxy_whitelist,
+            ..
         } = self.proxy.config()?;
 
         let actual_proxy_whitelist = HashSet::from_iter(proxy_whitelist.clone());

--- a/packages/abstract-core/src/core/manager.rs
+++ b/packages/abstract-core/src/core/manager.rs
@@ -153,6 +153,8 @@ pub enum ExecuteMsg {
     UpdateStatus { is_suspended: Option<bool> },
     /// Update settings for the Account, including IBC enabled, etc.
     UpdateSettings { ibc_enabled: Option<bool> },
+    /// Accept ownership of the proxy
+    AcceptProxyOwnership { proxy_address: String },
     /// Callback endpoint
     Callback(CallbackMsg),
 }

--- a/packages/abstract-core/src/core/proxy.rs
+++ b/packages/abstract-core/src/core/proxy.rs
@@ -21,37 +21,38 @@ use crate::{
     },
 };
 use cosmwasm_schema::QueryResponses;
-use cosmwasm_std::{CosmosMsg, Empty, Uint128};
+use cosmwasm_std::{Addr, CosmosMsg, Empty, Uint128};
 use cw_asset::{Asset, AssetInfo};
 
 pub mod state {
     pub use crate::objects::core::ACCOUNT_ID;
-    use cw_controllers::Admin;
 
     use cosmwasm_std::Addr;
     use cw_storage_plus::Item;
 
-    use crate::objects::{ans_host::AnsHost, common_namespace::ADMIN_NAMESPACE};
+    use crate::objects::ans_host::AnsHost;
+
     #[cosmwasm_schema::cw_serde]
     pub struct State {
         pub modules: Vec<Addr>,
     }
+
     pub const ANS_HOST: Item<AnsHost> = Item::new("\u{0}{6}ans_host");
     pub const STATE: Item<State> = Item::new("\u{0}{5}state");
-    pub const ADMIN: Admin = Admin::new(ADMIN_NAMESPACE);
 }
 
+/// Proxy instantiate msg
 #[cosmwasm_schema::cw_serde]
 pub struct InstantiateMsg {
     pub account_id: AccountId,
     pub ans_host_address: String,
 }
 
+/// Proxy Execute Messages
+#[cw_ownable::cw_ownable_execute]
 #[cosmwasm_schema::cw_serde]
 #[cfg_attr(feature = "boot", derive(boot_core::ExecuteFns))]
 pub enum ExecuteMsg {
-    /// Sets the admin
-    SetAdmin { admin: String },
     /// Executes the provided messages if sender is whitelisted
     ModuleAction { msgs: Vec<CosmosMsg<Empty>> },
     /// Execute IBC action on Client
@@ -66,9 +67,13 @@ pub enum ExecuteMsg {
         to_remove: Vec<AssetEntry>,
     },
 }
+
+/// Proxy migrate msg
 #[cosmwasm_schema::cw_serde]
 pub struct MigrateMsg {}
 
+/// Proxy query messages
+#[cw_ownable::cw_ownable_query]
 #[cosmwasm_schema::cw_serde]
 #[derive(QueryResponses)]
 #[cfg_attr(feature = "boot", derive(boot_core::QueryFns))]
@@ -115,6 +120,7 @@ pub enum QueryMsg {
 
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {
+    pub manager: Addr,
     pub modules: Vec<String>,
 }
 

--- a/packages/abstract-core/src/native/version_control.rs
+++ b/packages/abstract-core/src/native/version_control.rs
@@ -21,14 +21,10 @@ pub mod state {
     use cw_controllers::Admin;
     use cw_storage_plus::{Item, Map};
 
-    use crate::objects::{
-        common_namespace::ADMIN_NAMESPACE, core::AccountId, module::ModuleInfo,
-        module_reference::ModuleReference,
-    };
+    use crate::objects::{core::AccountId, module::ModuleInfo, module_reference::ModuleReference};
 
     use super::{AccountBase, Config};
 
-    pub const ADMIN: Admin = Admin::new(ADMIN_NAMESPACE);
     pub const FACTORY: Admin = Admin::new("factory");
 
     pub const CONFIG: Item<Config> = Item::new("config");

--- a/packages/abstract-testing/src/lib.rs
+++ b/packages/abstract-testing/src/lib.rs
@@ -9,7 +9,6 @@ use cosmwasm_std::{
 pub use mock_ans::MockAnsHost;
 pub use mock_querier::{map_key, mock_querier, raw_map_key, wrap_querier, MockQuerierBuilder};
 pub type MockDeps = OwnedDeps<MockStorage, MockApi, MockQuerier>;
-pub const OWNER: &str = "owner";
 pub mod addresses {
     use abstract_core::objects::AccountId;
     use abstract_core::version_control::AccountBase;
@@ -51,7 +50,6 @@ pub mod addresses {
 pub mod prelude {
     use super::*;
 
-    pub use super::OWNER;
     pub use abstract_mock_querier::{mocked_account_querier_builder, AbstractMockQuerierBuilder};
     pub use addresses::*;
     pub use mock_querier::{map_key, mock_querier, raw_map_key, wrap_querier, MockQuerierBuilder};


### PR DESCRIPTION
This change updates the `proxy` to use `cw-ownable`. Since the proxy is first owned by the `account-factory` and then transferred to the `manager`, a new `ExecuteMsg::AcceptProxyOwnership` was added to the `manager`. 

The ownership transfer is initiated by the `account-factory` and a new submessage was added to the Account-creation process to first transfer the ownership to the manager and then accept it through this new entry-point.

The logic for accepting the ownership does the following:
1) Check that the caller is the `account-factory`
2) Check the account id of the proxy and the manager to ensure they match
3) Accept the ownership as the manager