### PR TITLE
Refactor address responses to Addrs instead of Strings

### DIFF
--- a/contracts/account/manager/src/queries.rs
+++ b/contracts/account/manager/src/queries.rs
@@ -1,4 +1,4 @@
-use abstract_core::manager::state::SUSPENSION_STATUS;
+use abstract_core::manager::state::{Config, SUSPENSION_STATUS};
 use abstract_sdk::core::manager::state::{
     AccountInfo, ACCOUNT_ID, ACCOUNT_MODULES, CONFIG, INFO, OWNER,
 };
@@ -42,14 +42,18 @@ pub fn handle_config_query(deps: Deps) -> StdResult<Binary> {
         .get(deps)?
         .unwrap_or_else(|| Addr::unchecked(""))
         .to_string();
-    let config = CONFIG.load(deps.storage)?;
+    let Config {
+        version_control_address,
+        module_factory_address,
+        ..
+    } = CONFIG.load(deps.storage)?;
     let is_suspended = SUSPENSION_STATUS.load(deps.storage)?;
     to_binary(&ConfigResponse {
         owner,
         account_id,
         is_suspended,
-        version_control_address: config.version_control_address.to_string(),
-        module_factory_address: config.module_factory_address.into_string(),
+        version_control_address,
+        module_factory_address,
     })
 }
 pub fn handle_module_info_query(

--- a/contracts/account/manager/src/queries.rs
+++ b/contracts/account/manager/src/queries.rs
@@ -73,7 +73,7 @@ pub fn handle_module_info_query(
         resp_vec.push(ManagerModuleInfo {
             id,
             version,
-            address: address.to_string(),
+            address,
         })
     }
 

--- a/contracts/account/manager/src/queries.rs
+++ b/contracts/account/manager/src/queries.rs
@@ -18,10 +18,7 @@ const MAX_LIMIT: u8 = 10;
 
 pub fn handle_module_address_query(deps: Deps, env: Env, ids: Vec<String>) -> StdResult<Binary> {
     let contracts = query_module_addresses(deps, &env.contract.address, &ids)?;
-    let vector = contracts
-        .into_iter()
-        .map(|(v, k)| (v, k.to_string()))
-        .collect();
+    let vector = contracts.into_iter().map(|(v, k)| (v, k)).collect();
     to_binary(&ModuleAddressesResponse { modules: vector })
 }
 
@@ -33,7 +30,7 @@ pub fn handle_contract_versions_query(deps: Deps, env: Env, ids: Vec<String>) ->
 
 pub fn handle_account_info_query(deps: Deps) -> StdResult<Binary> {
     let info: AccountInfo = INFO.load(deps.storage)?;
-    to_binary(&InfoResponse { info: info.into() })
+    to_binary(&InfoResponse { info })
 }
 
 pub fn handle_config_query(deps: Deps) -> StdResult<Binary> {

--- a/contracts/account/manager/tests/apis.rs
+++ b/contracts/account/manager/tests/apis.rs
@@ -38,7 +38,7 @@ fn installing_one_api_should_succeed() -> AResult {
     let modules = account.expect_modules(vec![staking_api.address()?.to_string()])?;
 
     assert_that(&modules[1]).is_equal_to(&ManagerModuleInfo {
-        address: staking_api.addr_str()?,
+        address: staking_api.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -109,7 +109,7 @@ fn installation_of_duplicate_api_should_fail() -> AResult {
     // assert proxy module
     // check staking api
     assert_that(&modules[1]).is_equal_to(&ManagerModuleInfo {
-        address: staking_api.addr_str()?,
+        address: staking_api.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -142,7 +142,7 @@ fn reinstalling_api_should_be_allowed() -> AResult {
 
     // check staking api
     assert_that(&modules[1]).is_equal_to(&ManagerModuleInfo {
-        address: staking_api.addr_str()?,
+        address: staking_api.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -179,7 +179,7 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
 
     // check staking api
     assert_that(&modules[1]).is_equal_to(&ManagerModuleInfo {
-        address: staking_api.addr_str()?,
+        address: staking_api.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -213,7 +213,7 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
 
     assert_that!(modules[1]).is_equal_to(&ManagerModuleInfo {
         // the address stored for BootMockApi was updated when we instantiated the new version, so this is the new address
-        address: new_staking_api.addr_str()?,
+        address: new_staking_api.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -225,8 +225,7 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
     // assert that the new staking api has a different address
     assert_ne!(old_api_addr, new_staking_api.address()?);
 
-    assert_that!(modules[1].address)
-        .is_equal_to(new_staking_api.as_instance().address()?.to_string());
+    assert_that!(modules[1].address).is_equal_to(new_staking_api.as_instance().address()?);
 
     Ok(())
 }

--- a/contracts/account/manager/tests/proxy.rs
+++ b/contracts/account/manager/tests/proxy.rs
@@ -20,7 +20,7 @@ fn instantiate() -> AResult {
     // assert proxy module
     assert_that!(&modules).has_length(1);
     assert_that(&modules[0]).is_equal_to(&ManagerModuleInfo {
-        address: account.proxy.address()?.into_string(),
+        address: account.proxy.address()?,
         id: PROXY.to_string(),
         version: cw2::ContractVersion {
             contract: PROXY.into(),
@@ -31,8 +31,8 @@ fn instantiate() -> AResult {
     // assert manager config
     assert_that!(account.manager.config()?).is_equal_to(abstract_core::manager::ConfigResponse {
         owner: sender.to_string(),
-        version_control_address: deployment.version_control.address()?.into_string(),
-        module_factory_address: deployment.module_factory.address()?.into_string(),
+        version_control_address: deployment.version_control.address()?,
+        module_factory_address: deployment.module_factory.address()?,
         account_id: 0u32.into(),
         is_suspended: false,
     });

--- a/contracts/account/manager/tests/upgrades.rs
+++ b/contracts/account/manager/tests/upgrades.rs
@@ -29,7 +29,7 @@ fn install_module_version(
         },
     )?;
 
-    Ok(manager.module_info(module)?.unwrap().address)
+    Ok(manager.module_info(module)?.unwrap().address.to_string())
 }
 
 #[test]
@@ -320,7 +320,7 @@ fn update_api_with_authorized_addrs() -> AResult {
     use abstract_core::manager::QueryMsgFns as _;
     let api_v2 = manager.module_addresses(vec![api_1::MOCK_API_ID.into()])?;
     // assert that the address actually changed
-    assert_that!(api_v2.modules[0].1).is_not_equal_to(api1.clone());
+    assert_that!(api_v2.modules[0].1).is_not_equal_to(Addr::unchecked(api1.clone()));
 
     let api = api_1::BootMockApi1V2::new(chain);
     use abstract_core::api::BaseQueryMsgFns as _;

--- a/contracts/native/account-factory/src/contract.rs
+++ b/contracts/native/account-factory/src/contract.rs
@@ -114,9 +114,9 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
 
     let resp = ConfigResponse {
         owner: owner.unwrap(),
-        version_control_contract: state.version_control_contract.into(),
-        ans_host_contract: state.ans_host_contract.into(),
-        module_factory_address: state.module_factory_address.into(),
+        version_control_contract: state.version_control_contract,
+        ans_host_contract: state.ans_host_contract,
+        module_factory_address: state.module_factory_address,
         next_account_id: state.next_account_id,
     };
 

--- a/contracts/native/account-factory/tests/create_account.rs
+++ b/contracts/native/account-factory/tests/create_account.rs
@@ -27,8 +27,8 @@ fn instantiate() -> AResult {
     let expected = account_factory::ConfigResponse {
         owner: sender,
         ans_host_contract: deployment.ans_host.address()?.into(),
-        version_control_contract: deployment.version_control.address()?.into_string(),
-        module_factory_address: deployment.module_factory.address()?.into_string(),
+        version_control_contract: deployment.version_control.address()?,
+        module_factory_address: deployment.module_factory.address()?,
         next_account_id: 0,
     };
 
@@ -60,9 +60,9 @@ fn create_one_os() -> AResult {
     let factory_config = factory.config()?;
     let expected = account_factory::ConfigResponse {
         owner: sender.clone(),
-        ans_host_contract: deployment.ans_host.address()?.into(),
-        version_control_contract: deployment.version_control.address()?.into_string(),
-        module_factory_address: deployment.module_factory.address()?.into_string(),
+        ans_host_contract: deployment.ans_host.address()?,
+        version_control_contract: deployment.version_control.address()?,
+        module_factory_address: deployment.module_factory.address()?,
         next_account_id: 1,
     };
 
@@ -124,8 +124,8 @@ fn create_two_account_s() -> AResult {
     let expected = account_factory::ConfigResponse {
         owner: sender.clone(),
         ans_host_contract: deployment.ans_host.address()?.into(),
-        version_control_contract: deployment.version_control.address()?.into_string(),
-        module_factory_address: deployment.module_factory.address()?.into_string(),
+        version_control_contract: deployment.version_control.address()?,
+        module_factory_address: deployment.module_factory.address()?,
         next_account_id: 2,
     };
 

--- a/contracts/native/account-factory/tests/create_account.rs
+++ b/contracts/native/account-factory/tests/create_account.rs
@@ -195,8 +195,8 @@ fn sender_is_not_admin_monarchy() -> AResult {
     assert_that!(account_config).is_equal_to(abstract_core::manager::ConfigResponse {
         owner: owner.into_string(),
         account_id: Uint64::from(0u64),
-        version_control_address: version_control.address()?.into_string(),
-        module_factory_address: deployment.module_factory.address()?.into_string(),
+        version_control_address: version_control.address()?,
+        module_factory_address: deployment.module_factory.address()?,
         is_suspended: false,
     });
 
@@ -229,8 +229,8 @@ fn sender_is_not_admin_external() -> AResult {
         owner: owner.into_string(),
         account_id: Uint64::from(0u64),
         is_suspended: false,
-        version_control_address: version_control.address()?.into_string(),
-        module_factory_address: deployment.module_factory.address()?.into_string(),
+        version_control_address: version_control.address()?,
+        module_factory_address: deployment.module_factory.address()?,
     });
 
     Ok(())

--- a/contracts/native/ans-host/src/queries.rs
+++ b/contracts/native/ans-host/src/queries.rs
@@ -114,7 +114,7 @@ pub fn query_contract(deps: Deps, _env: Env, keys: Vec<&ContractEntry>) -> StdRe
     to_binary(&ContractsResponse {
         contracts: contracts
             .into_iter()
-            .map(|(x, a)| (x.to_owned(), a.to_string()))
+            .map(|(x, a)| (x.to_owned(), a))
             .collect(),
     })
 }
@@ -143,9 +143,7 @@ pub fn query_contract_list(
         .take(limit)
         .collect();
 
-    to_binary(&ContractListResponse {
-        contracts: res?.into_iter().map(|(x, a)| (x, a.to_string())).collect(),
-    })
+    to_binary(&ContractListResponse { contracts: res? })
 }
 
 pub fn query_channel_list(
@@ -622,7 +620,10 @@ mod test {
 
         // Stage data for equality test
         let expected = ContractsResponse {
-            contracts: create_contract_entry_and_string(vec![("foo", "foo", "foo")]),
+            contracts: create_contract_entry_and_string(vec![("foo", "foo", "foo")])
+                .into_iter()
+                .map(|(a, b)| (a, Addr::unchecked(b)))
+                .collect(),
         };
 
         // Assert
@@ -785,11 +786,17 @@ mod test {
             contracts: create_contract_entry_and_string(vec![
                 ("bar", "bar1", "bar2"),
                 ("foo", "foo1", "foo2"),
-            ]),
+            ])
+            .into_iter()
+            .map(|(a, b)| (a, Addr::unchecked(b)))
+            .collect(),
         };
 
         let expected_foo = ContractListResponse {
-            contracts: create_contract_entry_and_string(vec![("foo", "foo1", "foo2")]),
+            contracts: create_contract_entry_and_string(vec![("foo", "foo1", "foo2")])
+                .into_iter()
+                .map(|(a, b)| (a, Addr::unchecked(b)))
+                .collect(),
         };
 
         // Assert
@@ -797,7 +804,7 @@ mod test {
         assert_that!(&res).is_equal_to(&expected);
         // Assert - sanity check for duplication
         assert_that!(&res_expect_foo).is_equal_to(&expected_foo);
-        assert!(res.contracts.len() == 2_usize);
+        assert_eq!(res.contracts.len(), 2_usize);
 
         Ok(())
     }
@@ -866,7 +873,7 @@ mod test {
         assert_that!(&res_all).is_equal_to(expected_all);
         assert_that!(&res_foobar).is_equal_to(expected_foobar);
         assert_that!(&res_bar).is_equal_to(expected_bar);
-        assert!(res_all.channels.len() == 3_usize);
+        assert_eq!(res_all.channels.len(), 3_usize);
 
         Ok(())
     }

--- a/contracts/native/module-factory/src/contract.rs
+++ b/contracts/native/module-factory/src/contract.rs
@@ -99,8 +99,8 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     let admin = ADMIN.get(deps)?.unwrap();
     let resp = ConfigResponse {
         owner: admin.into(),
-        version_control_address: state.version_control_address.into(),
-        ans_host_address: state.ans_host_address.into(),
+        version_control_address: state.version_control_address,
+        ans_host_address: state.ans_host_address,
     };
 
     Ok(resp)

--- a/contracts/native/module-factory/tests/direct_calls.rs
+++ b/contracts/native/module-factory/tests/direct_calls.rs
@@ -17,8 +17,8 @@ fn instantiate() -> AResult {
     let factory_config = factory.config()?;
     let expected = module_factory::ConfigResponse {
         owner: sender.into_string(),
-        ans_host_address: deployment.ans_host.address()?.into(),
-        version_control_address: deployment.version_control.address()?.into_string(),
+        ans_host_address: deployment.ans_host.address()?,
+        version_control_address: deployment.version_control.address()?,
     };
 
     assert_that!(&factory_config).is_equal_to(&expected);

--- a/contracts/native/version-control/src/commands.rs
+++ b/contracts/native/version-control/src/commands.rs
@@ -368,8 +368,8 @@ mod test {
                 ManagerQueryMsg::Config {} => {
                     let resp = ManagerConfigResponse {
                         owner: TEST_OWNER.to_owned(),
-                        version_control_address: TEST_VERSION_CONTROL.to_owned(),
-                        module_factory_address: TEST_MODULE_FACTORY.to_owned(),
+                        version_control_address: Addr::unchecked(TEST_VERSION_CONTROL),
+                        module_factory_address: Addr::unchecked(TEST_MODULE_FACTORY),
                         account_id: Uint64::from(TEST_ACCOUNT_ID), // mock value, not used
                         is_suspended: false,
                     };

--- a/contracts/native/version-control/src/queries.rs
+++ b/contracts/native/version-control/src/queries.rs
@@ -273,8 +273,8 @@ mod test {
                     manager::QueryMsg::Config {} => {
                         let resp = manager::ConfigResponse {
                             owner: TEST_ADMIN.to_owned(),
-                            version_control_address: TEST_VERSION_CONTROL.to_owned(),
-                            module_factory_address: TEST_MODULE_FACTORY.to_owned(),
+                            version_control_address: Addr::unchecked(TEST_VERSION_CONTROL),
+                            module_factory_address: Addr::unchecked(TEST_MODULE_FACTORY),
                             account_id: Uint64::from(TEST_ACCOUNT_ID), // mock value, not used
                             is_suspended: false,
                         };
@@ -288,8 +288,8 @@ mod test {
                     manager::QueryMsg::Config {} => {
                         let resp = manager::ConfigResponse {
                             owner: TEST_OTHER.to_owned(),
-                            version_control_address: TEST_VERSION_CONTROL.to_owned(),
-                            module_factory_address: TEST_MODULE_FACTORY.to_owned(),
+                            version_control_address: Addr::unchecked(TEST_VERSION_CONTROL),
+                            module_factory_address: Addr::unchecked(TEST_MODULE_FACTORY),
                             account_id: Uint64::from(TEST_OTHER_ACCOUNT_ID), // mock value, not used
                             is_suspended: false,
                         };

--- a/contracts/native/version-control/tests/direct_calls.rs
+++ b/contracts/native/version-control/tests/direct_calls.rs
@@ -17,8 +17,8 @@ fn instantiate() -> AResult {
     let factory_config = factory.config()?;
     let expected = module_factory::ConfigResponse {
         owner: sender.into_string(),
-        ans_host_address: deployment.ans_host.address()?.into(),
-        version_control_address: deployment.version_control.address()?.into_string(),
+        ans_host_address: deployment.ans_host.address()?,
+        version_control_address: deployment.version_control.address()?,
     };
 
     assert_that!(&factory_config).is_equal_to(&expected);

--- a/packages/abstract-boot/src/account/mod.rs
+++ b/packages/abstract-boot/src/account/mod.rs
@@ -19,6 +19,7 @@ use abstract_core::{manager::ManagerModuleInfo, objects::AccountId};
 use boot_core::{
     CwEnv, {BootUpload, ContractInstance},
 };
+use cosmwasm_std::Addr;
 use serde::Serialize;
 use speculoos::prelude::*;
 
@@ -73,7 +74,8 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
         // insert proxy in expected module addresses
         let expected_module_addrs = module_addrs
             .into_iter()
-            .chain(std::iter::once(self.proxy.address()?.into_string()))
+            .map(Addr::unchecked)
+            .chain(std::iter::once(self.proxy.address()?))
             .collect::<HashSet<_>>();
 
         let actual_module_addrs = manager_modules

--- a/packages/abstract-core/src/core/manager.rs
+++ b/packages/abstract-core/src/core/manager.rs
@@ -188,7 +188,7 @@ pub struct ModuleVersionsResponse {
 
 #[cosmwasm_schema::cw_serde]
 pub struct ModuleAddressesResponse {
-    pub modules: Vec<(String, String)>,
+    pub modules: Vec<(String, Addr)>,
 }
 
 #[cosmwasm_schema::cw_serde]

--- a/packages/abstract-core/src/core/manager.rs
+++ b/packages/abstract-core/src/core/manager.rs
@@ -209,7 +209,7 @@ pub struct InfoResponse {
 pub struct ManagerModuleInfo {
     pub id: String,
     pub version: ContractVersion,
-    pub address: String,
+    pub address: Addr,
 }
 
 #[cosmwasm_schema::cw_serde]

--- a/packages/abstract-core/src/core/manager.rs
+++ b/packages/abstract-core/src/core/manager.rs
@@ -92,7 +92,7 @@ use crate::objects::{
     module::{Module, ModuleInfo},
 };
 use cosmwasm_schema::QueryResponses;
-use cosmwasm_std::{Binary, Uint64};
+use cosmwasm_std::{Addr, Binary, Uint64};
 use cw2::ContractVersion;
 
 #[cosmwasm_schema::cw_serde]
@@ -196,13 +196,13 @@ pub struct ConfigResponse {
     pub account_id: Uint64,
     pub owner: String,
     pub is_suspended: SuspensionStatus,
-    pub version_control_address: String,
-    pub module_factory_address: String,
+    pub version_control_address: Addr,
+    pub module_factory_address: Addr,
 }
 
 #[cosmwasm_schema::cw_serde]
 pub struct InfoResponse {
-    pub info: AccountInfo<String>,
+    pub info: AccountInfo<Addr>,
 }
 
 #[cosmwasm_schema::cw_serde]

--- a/packages/abstract-core/src/native/account_factory.rs
+++ b/packages/abstract-core/src/native/account_factory.rs
@@ -91,9 +91,9 @@ pub enum QueryMsg {
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {
     pub owner: Addr,
-    pub ans_host_contract: String,
-    pub version_control_contract: String,
-    pub module_factory_address: String,
+    pub ans_host_contract: Addr,
+    pub version_control_contract: Addr,
+    pub module_factory_address: Addr,
     pub next_account_id: AccountId,
 }
 

--- a/packages/abstract-core/src/native/ans_host.rs
+++ b/packages/abstract-core/src/native/ans_host.rs
@@ -292,13 +292,13 @@ pub struct AssetInfoListResponse {
 #[cosmwasm_schema::cw_serde]
 pub struct ContractsResponse {
     /// Contracts (name, address)
-    pub contracts: Vec<(ContractEntry, String)>,
+    pub contracts: Vec<ContractMapEntry>,
 }
 
 #[cosmwasm_schema::cw_serde]
 pub struct ContractListResponse {
     /// Contracts (name, address)
-    pub contracts: Vec<(ContractEntry, String)>,
+    pub contracts: Vec<ContractMapEntry>,
 }
 
 #[cosmwasm_schema::cw_serde]

--- a/packages/abstract-core/src/native/module_factory.rs
+++ b/packages/abstract-core/src/native/module_factory.rs
@@ -41,7 +41,7 @@ use crate::{
     version_control::AccountBase,
 };
 use cosmwasm_schema::QueryResponses;
-use cosmwasm_std::Binary;
+use cosmwasm_std::{Addr, Binary};
 
 #[cosmwasm_schema::cw_serde]
 pub struct InstantiateMsg {
@@ -90,8 +90,8 @@ pub enum QueryMsg {
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {
     pub owner: String,
-    pub ans_host_address: String,
-    pub version_control_address: String,
+    pub ans_host_address: Addr,
+    pub version_control_address: Addr,
 }
 
 #[cosmwasm_schema::cw_serde]


### PR DESCRIPTION
- Manager config response
- Manager module addresses
- Account factory config response
- Ans host contract list
- Module factory config response
- Fix integration tests with invalid addrs
