### PR TITLE
Use cw-ownable in the manager

### DIFF
--- a/contracts/account/manager/Cargo.toml
+++ b/contracts/account/manager/Cargo.toml
@@ -35,6 +35,7 @@ abstract-core = { workspace = true }
 semver = { workspace = true }
 cw-semver = { workspace = true }
 abstract-macros = { workspace = true }
+cw-ownable = { workspace = true }
 
 [dev-dependencies]
 cw20 = { workspace = true }

--- a/contracts/account/manager/src/contract.rs
+++ b/contracts/account/manager/src/contract.rs
@@ -9,7 +9,7 @@ use crate::{
 use abstract_core::manager::state::AccountInfo;
 use abstract_sdk::core::{
     manager::{
-        state::{Config, ACCOUNT_FACTORY, CONFIG, INFO, OWNER, SUSPENSION_STATUS},
+        state::{Config, ACCOUNT_FACTORY, CONFIG, INFO, SUSPENSION_STATUS},
         CallbackMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
     },
     objects::module_version::{migrate_module_data, set_module_data},
@@ -45,7 +45,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> ManagerResult {
 
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn instantiate(
-    mut deps: DepsMut,
+    deps: DepsMut,
     env: Env,
     info: MessageInfo,
     msg: InstantiateMsg,
@@ -82,7 +82,7 @@ pub fn instantiate(
     MIGRATE_CONTEXT.save(deps.storage, &vec![])?;
 
     // Set owner
-    OWNER.set(deps.branch(), Some(owner.clone()))?;
+    cw_ownable::initialize_owner(deps.storage, deps.api, Some(owner.as_str()))?;
     SUSPENSION_STATUS.save(deps.storage, &false)?;
     ACCOUNT_FACTORY.set(deps, Some(info.sender))?;
     Ok(ManagerResponse::new(
@@ -108,13 +108,13 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> M
             }
 
             match msg {
-                ExecuteMsg::SetOwner { owner } => set_owner(deps, info, owner),
+                ExecuteMsg::SetOwner { owner } => set_owner(deps, env, info, owner),
                 ExecuteMsg::UpdateModuleAddresses { to_add, to_remove } => {
                     // only Account Factory/Owner can add custom modules.
                     // required to add Proxy after init by Account Factory.
                     ACCOUNT_FACTORY
                         .assert_admin(deps.as_ref(), &info.sender)
-                        .or_else(|_| OWNER.assert_admin(deps.as_ref(), &info.sender))?;
+                        .or_else(|_| cw_ownable::assert_owner(deps.storage, &info.sender))?;
                     update_module_addresses(deps, to_add, to_remove)
                 }
                 ExecuteMsg::InstallModule { module, init_msg } => {
@@ -151,6 +151,22 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> M
                     Ok(response)
                 }
                 ExecuteMsg::Callback(CallbackMsg {}) => handle_callback(deps, env, info),
+                ExecuteMsg::UpdateOwnership(action) => match action {
+                    // Disallow the user from using the TransferOwnership action
+                    cw_ownable::Action::TransferOwnership { .. } => Err(StdError::generic_err(
+                        "Use the SetOwner message to transfer ownership",
+                    )
+                    .into()),
+                    _ => {
+                        abstract_sdk::execute_update_ownership!(
+                            ManagerResponse,
+                            deps,
+                            env,
+                            info,
+                            action
+                        )
+                    }
+                },
                 _ => panic!(),
             }
         }
@@ -183,6 +199,7 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> StdResult<Binary> {
         }
         QueryMsg::Info {} => handle_account_info_query(deps),
         QueryMsg::Config {} => handle_config_query(deps),
+        QueryMsg::Ownership {} => abstract_sdk::query_ownership!(deps),
     }
 }
 

--- a/contracts/account/manager/src/error.rs
+++ b/contracts/account/manager/src/error.rs
@@ -19,6 +19,9 @@ pub enum ManagerError {
     #[error("{0}")]
     Admin(#[from] AdminError),
 
+    #[error("{0}")]
+    Ownership(#[from] cw_ownable::OwnershipError),
+
     #[error("Module with id: {0} is already installed")]
     ModuleAlreadyInstalled(String),
 

--- a/contracts/account/manager/src/queries.rs
+++ b/contracts/account/manager/src/queries.rs
@@ -1,7 +1,5 @@
 use abstract_core::manager::state::SUSPENSION_STATUS;
-use abstract_sdk::core::manager::state::{
-    AccountInfo, ACCOUNT_ID, ACCOUNT_MODULES, CONFIG, INFO, OWNER,
-};
+use abstract_sdk::core::manager::state::{AccountInfo, ACCOUNT_ID, ACCOUNT_MODULES, CONFIG, INFO};
 use abstract_sdk::core::manager::{
     ConfigResponse, InfoResponse, ManagerModuleInfo, ModuleAddressesResponse, ModuleInfosResponse,
     ModuleVersionsResponse,
@@ -38,20 +36,18 @@ pub fn handle_account_info_query(deps: Deps) -> StdResult<Binary> {
 
 pub fn handle_config_query(deps: Deps) -> StdResult<Binary> {
     let account_id = Uint64::from(ACCOUNT_ID.load(deps.storage)?);
-    let owner = OWNER
-        .get(deps)?
-        .unwrap_or_else(|| Addr::unchecked(""))
-        .to_string();
+    let owner = cw_ownable::get_ownership(deps.storage)?.owner;
     let config = CONFIG.load(deps.storage)?;
     let is_suspended = SUSPENSION_STATUS.load(deps.storage)?;
     to_binary(&ConfigResponse {
-        owner,
+        owner: owner.unwrap_or_else(|| Addr::unchecked("")),
         account_id,
         is_suspended,
         version_control_address: config.version_control_address.to_string(),
         module_factory_address: config.module_factory_address.into_string(),
     })
 }
+
 pub fn handle_module_info_query(
     deps: Deps,
     last_module_id: Option<String>,

--- a/contracts/account/manager/tests/proxy.rs
+++ b/contracts/account/manager/tests/proxy.rs
@@ -30,7 +30,7 @@ fn instantiate() -> AResult {
 
     // assert manager config
     assert_that!(account.manager.config()?).is_equal_to(abstract_core::manager::ConfigResponse {
-        owner: sender.to_string(),
+        owner: sender,
         version_control_address: deployment.version_control.address()?.into_string(),
         module_factory_address: deployment.module_factory.address()?.into_string(),
         account_id: 0u32.into(),

--- a/contracts/native/account-factory/src/contract.rs
+++ b/contracts/native/account-factory/src/contract.rs
@@ -110,7 +110,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 
 pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     let state: Config = CONFIG.load(deps.storage)?;
-    let cw_ownable::Ownership { owner, .. } = cw_ownable::get_ownership(deps.storage)?;
+    let owner = cw_ownable::get_ownership(deps.storage)?.owner;
 
     let resp = ConfigResponse {
         owner: owner.unwrap(),

--- a/contracts/native/account-factory/tests/create_account.rs
+++ b/contracts/native/account-factory/tests/create_account.rs
@@ -193,7 +193,7 @@ fn sender_is_not_admin_monarchy() -> AResult {
     let account_config = account_1.manager.config()?;
 
     assert_that!(account_config).is_equal_to(abstract_core::manager::ConfigResponse {
-        owner: owner.into_string(),
+        owner,
         account_id: Uint64::from(0u64),
         version_control_address: version_control.address()?.into_string(),
         module_factory_address: deployment.module_factory.address()?.into_string(),
@@ -226,7 +226,7 @@ fn sender_is_not_admin_external() -> AResult {
     let account_config = account.manager.config()?;
 
     assert_that!(account_config).is_equal_to(abstract_core::manager::ConfigResponse {
-        owner: owner.into_string(),
+        owner,
         account_id: Uint64::from(0u64),
         is_suspended: false,
         version_control_address: version_control.address()?.into_string(),

--- a/contracts/native/ans-host/src/queries.rs
+++ b/contracts/native/ans-host/src/queries.rs
@@ -29,7 +29,7 @@ pub fn query_config(deps: Deps) -> StdResult<Binary> {
         next_unique_pool_id,
     } = CONFIG.load(deps.storage)?;
 
-    let cw_ownable::Ownership { owner, .. } = cw_ownable::get_ownership(deps.storage)?;
+    let owner = cw_ownable::get_ownership(deps.storage)?.owner;
 
     let res = ConfigResponse {
         next_unique_pool_id,

--- a/contracts/native/version-control/src/commands.rs
+++ b/contracts/native/version-control/src/commands.rs
@@ -187,7 +187,7 @@ pub fn claim_namespaces(
     let account_owner = query_account_owner(&deps.querier, &account_base.manager)?;
     if msg_info.sender != account_owner {
         return Err(VCError::AccountOwnerMismatch {
-            sender: msg_info.sender.into_string(),
+            sender: msg_info.sender,
             owner: account_owner,
         });
     }
@@ -302,7 +302,7 @@ pub fn update_namespaces_limit(deps: DepsMut, info: MessageInfo, new_limit: u32)
     ))
 }
 
-pub fn query_account_owner(querier: &QuerierWrapper, manager_addr: &Addr) -> StdResult<String> {
+pub fn query_account_owner(querier: &QuerierWrapper, manager_addr: &Addr) -> StdResult<Addr> {
     let ManagerConfigResponse { owner, .. } =
         querier.query_wasm_smart(manager_addr, &ManagerQueryMsg::Config {})?;
     Ok(owner)
@@ -320,7 +320,7 @@ pub fn validate_account_owner(deps: Deps, namespace: &str, sender: &Addr) -> Res
     let account_owner = query_account_owner(&deps.querier, &account_base.manager)?;
     if sender != account_owner {
         return Err(VCError::AccountOwnerMismatch {
-            sender: sender.into_string(),
+            sender,
             owner: account_owner,
         });
     }
@@ -367,7 +367,7 @@ mod test {
             match from_binary(msg).unwrap() {
                 ManagerQueryMsg::Config {} => {
                     let resp = ManagerConfigResponse {
-                        owner: TEST_OWNER.to_owned(),
+                        owner: Addr::unchecked(TEST_OWNER),
                         version_control_address: TEST_VERSION_CONTROL.to_owned(),
                         module_factory_address: TEST_MODULE_FACTORY.to_owned(),
                         account_id: Uint64::from(TEST_ACCOUNT_ID), // mock value, not used
@@ -573,8 +573,8 @@ mod test {
             assert_that!(&res)
                 .is_err()
                 .is_equal_to(&VCError::AccountOwnerMismatch {
-                    sender: TEST_OTHER.to_string(),
-                    owner: TEST_OWNER.to_string(),
+                    sender: Addr::unchecked(TEST_OTHER),
+                    owner: Addr::unchecked(TEST_OWNER),
                 });
             Ok(())
         }
@@ -695,8 +695,8 @@ mod test {
             assert_that!(&res)
                 .is_err()
                 .is_equal_to(&VCError::AccountOwnerMismatch {
-                    sender: TEST_OTHER.to_string(),
-                    owner: TEST_OWNER.to_string(),
+                    sender: Addr::unchecked(TEST_OTHER),
+                    owner: Addr::unchecked(TEST_OWNER),
                 });
             Ok(())
         }
@@ -1032,8 +1032,8 @@ mod test {
             assert_that!(&res)
                 .is_err()
                 .is_equal_to(&VCError::AccountOwnerMismatch {
-                    sender: TEST_OTHER.to_string(),
-                    owner: TEST_OWNER.to_string(),
+                    sender: Addr::unchecked(TEST_OTHER),
+                    owner: Addr::unchecked(TEST_OWNER),
                 });
 
             Ok(())

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -109,7 +109,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::Modules { infos } => queries::handle_modules_query(deps, infos),
         QueryMsg::Namespaces { accounts } => queries::handle_namespaces_query(deps, accounts),
         QueryMsg::Config {} => {
-            let cw_ownable::Ownership { owner, .. } = cw_ownable::get_ownership(deps.storage)?;
+            let owner = cw_ownable::get_ownership(deps.storage)?.owner;
 
             let factory = FACTORY.get(deps)?.unwrap();
             to_binary(&ConfigResponse {

--- a/contracts/native/version-control/src/error.rs
+++ b/contracts/native/version-control/src/error.rs
@@ -1,6 +1,6 @@
 use abstract_core::{objects::AccountId, AbstractError};
 use abstract_sdk::{core::objects::module::ModuleInfo, AbstractSdkError};
-use cosmwasm_std::StdError;
+use cosmwasm_std::{Addr, StdError};
 use cw_controllers::AdminError;
 use thiserror::Error;
 
@@ -40,7 +40,7 @@ pub enum VCError {
     UnknownNamespace { namespace: String },
 
     #[error("Account owner mismatch sender: {}, owner: {}", sender, owner)]
-    AccountOwnerMismatch { sender: String, owner: String },
+    AccountOwnerMismatch { sender: Addr, owner: Addr },
 
     #[error("Namespace {} is already occupied by {}", namespace, id)]
     NamespaceOccupied { namespace: String, id: AccountId },

--- a/contracts/native/version-control/src/queries.rs
+++ b/contracts/native/version-control/src/queries.rs
@@ -272,7 +272,7 @@ mod test {
                 match from_binary(msg).unwrap() {
                     manager::QueryMsg::Config {} => {
                         let resp = manager::ConfigResponse {
-                            owner: TEST_ADMIN.to_owned(),
+                            owner: Addr::unchecked(TEST_ADMIN),
                             version_control_address: TEST_VERSION_CONTROL.to_owned(),
                             module_factory_address: TEST_MODULE_FACTORY.to_owned(),
                             account_id: Uint64::from(TEST_ACCOUNT_ID), // mock value, not used
@@ -287,7 +287,7 @@ mod test {
                 match from_binary(msg).unwrap() {
                     manager::QueryMsg::Config {} => {
                         let resp = manager::ConfigResponse {
-                            owner: TEST_OTHER.to_owned(),
+                            owner: Addr::unchecked(TEST_OTHER),
                             version_control_address: TEST_VERSION_CONTROL.to_owned(),
                             module_factory_address: TEST_MODULE_FACTORY.to_owned(),
                             account_id: Uint64::from(TEST_OTHER_ACCOUNT_ID), // mock value, not used

--- a/packages/abstract-core/src/core/manager.rs
+++ b/packages/abstract-core/src/core/manager.rs
@@ -22,6 +22,7 @@ pub mod state {
     use cosmwasm_std::{Addr, Api};
     use cw_address_like::AddressLike;
     use cw_controllers::Admin;
+    use cw_ownable::Ownership;
     use cw_storage_plus::{Item, Map};
 
     pub type SuspensionStatus = bool;
@@ -75,8 +76,8 @@ pub mod state {
     pub const INFO: Item<AccountInfo<Addr>> = Item::new("\u{0}{4}info");
     /// Contract Admin
     pub const ACCOUNT_FACTORY: Admin = Admin::new("\u{0}{7}factory");
-    /// Account owner
-    pub const OWNER: Admin = Admin::new("owner");
+    /// Account owner - managed by cw-ownable
+    pub const OWNER: Item<Ownership<Addr>> = Item::new("ownership");
     /// Enabled Abstract modules
     pub const ACCOUNT_MODULES: Map<ModuleId, Addr> = Map::new("modules");
     /// Stores the dependency relationship between modules
@@ -92,7 +93,7 @@ use crate::objects::{
     module::{Module, ModuleInfo},
 };
 use cosmwasm_schema::QueryResponses;
-use cosmwasm_std::{Binary, Uint64};
+use cosmwasm_std::{Addr, Binary, Uint64};
 use cw2::ContractVersion;
 
 #[cosmwasm_schema::cw_serde]
@@ -112,7 +113,8 @@ pub struct InstantiateMsg {
 #[cosmwasm_schema::cw_serde]
 pub struct CallbackMsg {}
 
-/// Execute messages
+/// Manager execute messages
+#[cw_ownable::cw_ownable_execute]
 #[cosmwasm_schema::cw_serde]
 #[cfg_attr(feature = "boot", derive(boot_core::ExecuteFns))]
 pub enum ExecuteMsg {
@@ -157,6 +159,8 @@ pub enum ExecuteMsg {
     Callback(CallbackMsg),
 }
 
+/// Manager query messages
+#[cw_ownable::cw_ownable_query]
 #[cosmwasm_schema::cw_serde]
 #[derive(QueryResponses)]
 #[cfg_attr(feature = "boot", derive(boot_core::QueryFns))]
@@ -194,7 +198,7 @@ pub struct ModuleAddressesResponse {
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {
     pub account_id: Uint64,
-    pub owner: String,
+    pub owner: Addr,
     pub is_suspended: SuspensionStatus,
     pub version_control_address: String,
     pub module_factory_address: String,


### PR DESCRIPTION
This change changes the manager's "owner" (Account owner) to use `cw-ownable`. The difference between this implementation and the rest is that `ExecuteMsg::UpdateOwnership(cw_ownable::Action::TransferOwnership {..})` is blocked, with the `SetOwner` method intended to be the correct route for the user.