### PR TITLE
Remove owner from ConfigResponses

### DIFF
--- a/contracts/native/account-factory/src/contract.rs
+++ b/contracts/native/account-factory/src/contract.rs
@@ -3,7 +3,7 @@ use abstract_core::objects::module_version::assert_contract_upgrade;
 use abstract_macros::abstract_response;
 use abstract_sdk::core::{account_factory::*, ACCOUNT_FACTORY};
 use cosmwasm_std::{
-    to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
 };
 
 use abstract_sdk::{execute_update_ownership, query_ownership};
@@ -99,10 +99,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 
 pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     let state: Config = CONFIG.load(deps.storage)?;
-    let cw_ownable::Ownership { owner, .. } = cw_ownable::get_ownership(deps.storage)?;
 
     let resp = ConfigResponse {
-        owner: owner.unwrap_or_else(|| Addr::unchecked("")),
         version_control_contract: state.version_control_contract,
         ans_host_contract: state.ans_host_contract,
         module_factory_address: state.module_factory_address,

--- a/contracts/native/account-factory/tests/create_account.rs
+++ b/contracts/native/account-factory/tests/create_account.rs
@@ -25,7 +25,6 @@ fn instantiate() -> AResult {
     let factory = deployment.account_factory;
     let factory_config = factory.config()?;
     let expected = account_factory::ConfigResponse {
-        owner: sender,
         ans_host_contract: deployment.ans_host.address()?,
         version_control_contract: deployment.version_control.address()?,
         module_factory_address: deployment.module_factory.address()?,
@@ -59,7 +58,6 @@ fn create_one_os() -> AResult {
 
     let factory_config = factory.config()?;
     let expected = account_factory::ConfigResponse {
-        owner: sender.clone(),
         ans_host_contract: deployment.ans_host.address()?,
         version_control_contract: deployment.version_control.address()?,
         module_factory_address: deployment.module_factory.address()?,
@@ -70,7 +68,6 @@ fn create_one_os() -> AResult {
 
     let vc_config = version_control.config()?;
     let expected = abstract_core::version_control::ConfigResponse {
-        admin: sender,
         factory: factory.address()?,
     };
 
@@ -122,7 +119,6 @@ fn create_two_account_s() -> AResult {
 
     let factory_config = factory.config()?;
     let expected = account_factory::ConfigResponse {
-        owner: sender.clone(),
         ans_host_contract: deployment.ans_host.address()?,
         version_control_contract: deployment.version_control.address()?,
         module_factory_address: deployment.module_factory.address()?,
@@ -133,7 +129,6 @@ fn create_two_account_s() -> AResult {
 
     let vc_config = version_control.config()?;
     let expected = abstract_core::version_control::ConfigResponse {
-        admin: sender,
         factory: factory.address()?,
     };
 

--- a/contracts/native/ans-host/src/queries.rs
+++ b/contracts/native/ans-host/src/queries.rs
@@ -29,11 +29,8 @@ pub fn query_config(deps: Deps) -> StdResult<Binary> {
         next_unique_pool_id,
     } = CONFIG.load(deps.storage)?;
 
-    let cw_ownable::Ownership { owner, .. } = cw_ownable::get_ownership(deps.storage)?;
-
     let res = ConfigResponse {
         next_unique_pool_id,
-        admin: owner.unwrap(),
     };
 
     to_binary(&res)

--- a/contracts/native/module-factory/src/contract.rs
+++ b/contracts/native/module-factory/src/contract.rs
@@ -3,7 +3,7 @@ use abstract_core::objects::module_version::assert_contract_upgrade;
 use abstract_macros::abstract_response;
 use abstract_sdk::core::{module_factory::*, MODULE_FACTORY};
 use cosmwasm_std::{
-    to_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, StdResult,
 };
 use cw2::set_contract_version;
 use semver::Version;
@@ -94,9 +94,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 
 pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     let state: Config = CONFIG.load(deps.storage)?;
-    let owner = cw_ownable::get_ownership(deps.storage)?.owner;
     let resp = ConfigResponse {
-        owner: owner.unwrap_or_else(|| Addr::unchecked("")),
         version_control_address: state.version_control_address,
         ans_host_address: state.ans_host_address,
     };

--- a/contracts/native/module-factory/tests/direct_calls.rs
+++ b/contracts/native/module-factory/tests/direct_calls.rs
@@ -16,7 +16,6 @@ fn instantiate() -> AResult {
     let factory = deployment.module_factory;
     let factory_config = factory.config()?;
     let expected = module_factory::ConfigResponse {
-        owner: sender,
         ans_host_address: deployment.ans_host.address()?,
         version_control_address: deployment.version_control.address()?,
     };

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -97,13 +97,8 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
         QueryMsg::Modules { infos } => queries::handle_modules_query(deps, infos),
         QueryMsg::Namespaces { accounts } => queries::handle_namespaces_query(deps, accounts),
         QueryMsg::Config {} => {
-            let cw_ownable::Ownership { owner, .. } = cw_ownable::get_ownership(deps.storage)?;
-
             let factory = FACTORY.get(deps)?.unwrap();
-            to_binary(&ConfigResponse {
-                admin: owner.unwrap(),
-                factory,
-            })
+            to_binary(&ConfigResponse { factory })
         }
         QueryMsg::ModuleList {
             filter,

--- a/contracts/native/version-control/tests/direct_calls.rs
+++ b/contracts/native/version-control/tests/direct_calls.rs
@@ -16,7 +16,6 @@ fn instantiate() -> AResult {
     let factory = deployment.module_factory;
     let factory_config = factory.config()?;
     let expected = module_factory::ConfigResponse {
-        owner: sender,
         ans_host_address: deployment.ans_host.address()?,
         version_control_address: deployment.version_control.address()?,
     };

--- a/packages/abstract-core/src/native/account_factory.rs
+++ b/packages/abstract-core/src/native/account_factory.rs
@@ -90,7 +90,6 @@ pub enum QueryMsg {
 /// Account Factory config response
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {
-    pub owner: Addr,
     pub ans_host_contract: Addr,
     pub version_control_contract: Addr,
     pub module_factory_address: Addr,

--- a/packages/abstract-core/src/native/ans_host.rs
+++ b/packages/abstract-core/src/native/ans_host.rs
@@ -261,7 +261,6 @@ pub struct MigrateMsg {}
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {
     pub next_unique_pool_id: UniquePoolId,
-    pub admin: Addr,
 }
 /// Query response
 #[cosmwasm_schema::cw_serde]

--- a/packages/abstract-core/src/native/module_factory.rs
+++ b/packages/abstract-core/src/native/module_factory.rs
@@ -87,7 +87,6 @@ pub enum QueryMsg {
 /// Module factory config response
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {
-    pub owner: Addr,
     pub ans_host_address: Addr,
     pub version_control_address: Addr,
 }

--- a/packages/abstract-core/src/native/version_control.rs
+++ b/packages/abstract-core/src/native/version_control.rs
@@ -206,7 +206,6 @@ pub struct NamespaceListResponse {
 
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {
-    pub admin: Addr,
     pub factory: Addr,
 }
 


### PR DESCRIPTION
This change removes the `owner` and `admin` from `ConfigResponse`s in our contracts because it's exposed by the `QueryMsg::Ownership`